### PR TITLE
Loan refactor

### DIFF
--- a/contracts/.solhint.json
+++ b/contracts/.solhint.json
@@ -1,0 +1,11 @@
+{
+    "extends": "default",
+    "rules": {
+        "not-rely-on-time": false,
+        "separate-by-one-line-in-contract": "warn",
+        "separate-by-one-line-in-contract": "warn",
+        "expression-indent": "warn",
+        "indent": "warn",
+        "func-order": "warn"
+    }
+}

--- a/contracts/.solhint.json
+++ b/contracts/.solhint.json
@@ -6,6 +6,7 @@
         "separate-by-one-line-in-contract": "warn",
         "expression-indent": "warn",
         "indent": "warn",
-        "func-order": "warn"
+        "func-order": "warn",
+        "statement-indent": "warn"
     }
 }

--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -284,9 +284,14 @@ contract LoanManager is Restricted {
 
         loans[loanId].state = LoanState.Repaid;
 
-        augmintToken.transfer(interestEarnedAccount, interestAmount);
+        if (interestAmount > 0) {
+            augmintToken.transfer(interestEarnedAccount, interestAmount);
+            augmintToken.burn(loanAmount);
+        } else {
+            // negative or zero interest (i.e. discountRate >= 0)
+            augmintToken.burn(repaymentAmount);
+        }
 
-        augmintToken.burn(loanAmount);
         monetarySupervisor.loanRepaymentNotification(loanAmount); // update KPIs
 
         loan.borrower.transfer(loan.collateralAmount); // send back ETH collateral

--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -49,7 +49,7 @@ contract LoanManager is Restricted {
     LoanProduct[] public products;
 
     LoanData[] public loans;
-    mapping(address => uint[]) public mLoans;  // owner account address =>  array of loan Ids
+    mapping(address => uint[]) public accountLoans;  // owner account address =>  array of loan Ids
 
     Rates public rates; // instance of ETH/pegged currency rate provider contract
     AugmintTokenInterface public augmintToken; // instance of token contract
@@ -119,7 +119,7 @@ contract LoanManager is Restricted {
                                             productId, LoanState.Open, maturity)) - 1;
 
         // Store ref to new loan
-        mLoans[msg.sender].push(loanId);
+        accountLoans[msg.sender].push(loanId);
 
         // Issue tokens and send to borrower
         monetarySupervisor.issueLoan(msg.sender, loanAmount);
@@ -200,7 +200,7 @@ contract LoanManager is Restricted {
     }
 
     function getLoanIds(address borrower) external view returns (uint[] _loans) {
-        return mLoans[borrower];
+        return accountLoans[borrower];
     }
 
     /* repay loan, called from AugmintToken's transferAndNotify

--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -22,6 +22,8 @@ import "./MonetarySupervisor.sol";
 contract LoanManager is Restricted {
     using SafeMath for uint256;
 
+    uint16 public constant CHUNK_SIZE = 100;
+
     enum LoanState { Open, Repaid, Defaulted }
 
     struct LoanProduct {
@@ -175,12 +177,26 @@ contract LoanManager is Restricted {
 
     }
 
-    function getLoanCount() external view returns (uint ct) {
-        return loans.length;
-    }
-
     function getProductCount() external view returns (uint ct) {
         return products.length;
+    }
+
+    // returns CHUNK_SIZE loan products starting from some offset:
+    // [ productId, minDisbursedAmount, term, discountRate, collateralRatio, defaultingFeePt, isActive ]
+    function getProducts(uint offset) external view returns (uint[7][CHUNK_SIZE] response) {
+        for (uint16 i = 0; i < CHUNK_SIZE; i++) {
+
+            if (offset + i >= products.length) { break; }
+
+            LoanProduct storage product = products[offset + i];
+
+            response[i] = [offset + i, product.minDisbursedAmount, product.term, product.discountRate,
+                                product.collateralRatio, product.defaultingFeePt, product.isActive ? 1 : 0 ];
+        }
+    }
+
+    function getLoanCount() external view returns (uint ct) {
+        return loans.length;
     }
 
     function getLoanIds(address borrower) external view returns (uint[] _loans) {

--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -208,19 +208,7 @@ contract LoanManager is Restricted {
 
             if (offset + i >= loans.length) { break; }
 
-            LoanData storage loan = loans[offset + i];
-            LoanProduct storage product = products[loan.productId];
-
-            uint loanAmount;
-            uint interestAmount;
-            (loanAmount, interestAmount) = calculateLoanValues(product, loan.repaymentAmount);
-            uint disbursementTime = loan.maturity - product.term;
-
-            LoanState loanState =
-                            loan.state == LoanState.Open && now >= loan.maturity ? LoanState.Defaulted : loan.state;
-
-            response[i] = [offset + i, loan.collateralAmount, loan.repaymentAmount, uint(loan.borrower),
-                        loan.productId, uint(loanState), loan.maturity, disbursementTime, loanAmount, interestAmount];
+            response[i] = getLoanTuple(offset + i);
         }
     }
 
@@ -239,22 +227,24 @@ contract LoanManager is Restricted {
 
             if (offset + i >= loansForAddress.length) { break; }
 
-            uint loanId = loansForAddress[offset + i];
-
-            LoanData storage loan = loans[loanId];
-            LoanProduct storage product = products[loan.productId];
-
-            uint loanAmount;
-            uint interestAmount;
-            (loanAmount, interestAmount) = calculateLoanValues(product, loan.repaymentAmount);
-            uint disbursementTime = loan.maturity - product.term;
-
-            LoanState loanState =
-                            loan.state == LoanState.Open && now >= loan.maturity? LoanState.Defaulted : loan.state;
-
-            response[i] = [loanId, loan.collateralAmount, loan.repaymentAmount, uint(loan.borrower),
-                        loan.productId, uint(loanState), loan.maturity, disbursementTime, loanAmount, interestAmount];
+            response[i] = getLoanTuple(loansForAddress[offset + i]);
         }
+    }
+
+    function getLoanTuple(uint loanId) public view returns (uint[10] result) {
+        LoanData storage loan = loans[loanId];
+        LoanProduct storage product = products[loan.productId];
+
+        uint loanAmount;
+        uint interestAmount;
+        (loanAmount, interestAmount) = calculateLoanValues(product, loan.repaymentAmount);
+        uint disbursementTime = loan.maturity - product.term;
+
+        LoanState loanState =
+                        loan.state == LoanState.Open && now >= loan.maturity ? LoanState.Defaulted : loan.state;
+
+        result = [loanId, loan.collateralAmount, loan.repaymentAmount, uint(loan.borrower),
+                    loan.productId, uint(loanState), loan.maturity, disbursementTime, loanAmount, interestAmount];
     }
 
     /* repay loan, called from AugmintToken's transferAndNotify

--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -57,7 +57,7 @@ contract LoanManager is Restricted {
     InterestEarnedAccount public interestEarnedAccount;
 
     event NewLoan(uint32 productId, uint loanId, address indexed borrower, uint collateralAmount, uint loanAmount,
-        uint repaymentAmount);
+        uint repaymentAmount, uint40 maturity);
 
     event LoanProductActiveStateChanged(uint32 productId, bool newState);
 
@@ -124,7 +124,7 @@ contract LoanManager is Restricted {
         // Issue tokens and send to borrower
         monetarySupervisor.issueLoan(msg.sender, loanAmount);
 
-        NewLoan(productId, loanId, msg.sender, msg.value, loanAmount, repaymentAmount);
+        NewLoan(productId, loanId, msg.sender, msg.value, loanAmount, repaymentAmount, maturity);
     }
 
     function collect(uint[] loanIds) external {

--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -25,13 +25,13 @@ contract LoanManager is Restricted {
     enum LoanState { Open, Repaid, Defaulted }
 
     struct LoanProduct {
-        uint term; // 0
-        uint discountRate; // 1: discountRate in parts per million , ie. 10,000 = 1%
-        uint collateralRatio;   // 2: loan token amount / colleteral pegged ccy value
-                                // in parts per million , ie. 10,000 = 1%
-        uint minDisbursedAmount; // 3: with 4 decimals, e.g. 31000 = 3.1ACE
-        uint defaultingFeePt; // 4: % of collateral in parts per million , ie. 50,000 = 5%
-        bool isActive; // 5
+        uint minDisbursedAmount; // 0: with decimals set in AugmintToken.decimals
+        uint32 term;            // 1
+        uint32 discountRate;    // 2: discountRate in parts per million , ie. 10,000 = 1%
+        uint32 collateralRatio; // 3: loan token amount / colleteral pegged ccy value
+                                //      in parts per million , ie. 10,000 = 1%
+        uint32 defaultingFeePt; // 4: % of collateral in parts per million , ie. 50,000 = 5%
+        bool isActive;          // 5
     }
 
     /* NB: we don't need to store loan parameters because loan products can't be altered (only disabled/enabled) */
@@ -75,12 +75,12 @@ contract LoanManager is Restricted {
         interestEarnedAccount = _interestEarnedAccount;
     }
 
-    function addLoanProduct(uint _term, uint _discountRate, uint _collateralRatio, uint _minDisbursedAmount,
-                                uint _defaultingFee, bool _isActive)
+    function addLoanProduct(uint32 term, uint32 discountRate, uint32 collateralRatio, uint minDisbursedAmount,
+                                uint32 defaultingFeePt, bool isActive)
     external restrict("MonetaryBoard") {
 
         uint _newProductId = products.push(
-            LoanProduct(_term, _discountRate, _collateralRatio, _minDisbursedAmount, _defaultingFee, _isActive)
+            LoanProduct(minDisbursedAmount, term, discountRate, collateralRatio, defaultingFeePt, isActive)
         ) - 1;
 
         uint32 newProductId = uint32(_newProductId);

--- a/contracts/LoanManager.sol
+++ b/contracts/LoanManager.sol
@@ -103,7 +103,7 @@ contract LoanManager is Restricted {
 
         // calculate loan values based on ETH sent in with Tx
         uint tokenValue = rates.convertFromWei(augmintToken.peggedSymbol(), msg.value);
-        uint repaymentAmount = tokenValue.mul(product.collateralRatio).roundedDiv(1000000);
+        uint repaymentAmount = tokenValue.mul(product.collateralRatio).div(1000000);
 
         uint loanAmount;
         (loanAmount, ) = calculateLoanValues(product, repaymentAmount);
@@ -266,7 +266,7 @@ contract LoanManager is Restricted {
     function calculateLoanValues(LoanProduct storage product, uint repaymentAmount)
     internal view returns (uint loanAmount, uint interestAmount) {
         // calculate loan values based on repayment amount
-        loanAmount = repaymentAmount.mul(product.discountRate).roundedDiv(1000000);
+        loanAmount = repaymentAmount.mul(product.discountRate).div(1000000);
         interestAmount = loanAmount > repaymentAmount ? 0 : repaymentAmount.sub(loanAmount);
     }
 

--- a/test/helpers/loanTestHelpers.js
+++ b/test/helpers/loanTestHelpers.js
@@ -7,8 +7,8 @@ const Rates = artifacts.require("./Rates.sol");
 const tokenTestHelpers = require("./tokenTestHelpers.js");
 const testHelpers = require("./testHelpers.js");
 
-const NEWLOAN_MAX_GAS = 350000;
-const REPAY_MAX_GAS = 150000;
+const NEWLOAN_MAX_GAS = 210000;
+const REPAY_MAX_GAS = 120000;
 const COLLECT_BASE_GAS = 100000;
 
 let augmintToken = null;

--- a/test/helpers/loanTestHelpers.js
+++ b/test/helpers/loanTestHelpers.js
@@ -211,7 +211,7 @@ async function repayLoan(testInstance, loan) {
 
 async function collectLoan(testInstance, loan, collector) {
     loan.collector = collector;
-    loan.state = 2; // defaulted
+    loan.state = 3; // Collected
 
     const targetCollectionInToken = loan.repaymentAmount.mul(loan.product.defaultingFeePt.add(1000000)).div(1000000);
     const targetFeeInToken = loan.repaymentAmount.mul(loan.product.defaultingFeePt).div(1000000);
@@ -263,16 +263,8 @@ async function collectLoan(testInstance, loan, collector) {
     //      defaultingFee: ${web3.fromWei(defaultingFee).toString()} ETH`
     // );
 
-    // console.log(
-    //     "DEBUG. Borrower balance before collection:",
-    //     ((await web3.eth.getBalance(loan.borrower)) / ONE_ETH).toString()
-    // );
     const tx = await loanManager.collect([loan.id], { from: loan.collector });
     testHelpers.logGasUse(testInstance, tx, "collect 1");
-    // console.log(
-    //     "DEBUG. Borrower balance after collection:",
-    //     ((await web3.eth.getBalance(loan.borrower)) / ONE_ETH).toString()
-    // );
 
     const [totalSupplyAfter, totalLoanAmountAfter, , ,] = await Promise.all([
         augmintToken.totalSupply(),

--- a/test/helpers/loanTestHelpers.js
+++ b/test/helpers/loanTestHelpers.js
@@ -374,13 +374,13 @@ async function calcLoanValues(rates, product, collateralWei) {
     ret.repaymentAmount = ret.tokenValue
         .mul(product.collateralRatio)
         .div(ppmDiv)
-        .round(0, BigNumber.ROUND_HALF_UP);
+        .round(0, BigNumber.ROUND_DOWN);
 
     ret.loanAmount = ret.tokenValue
         .mul(product.collateralRatio)
         .mul(product.discountRate)
         .div(ppmDiv * ppmDiv)
-        .round(0, BigNumber.ROUND_HALF_UP);
+        .round(0, BigNumber.ROUND_DOWN);
 
     ret.interestAmount = ret.repaymentAmount.minus(ret.loanAmount);
     ret.disbursementTime = moment()

--- a/test/helpers/loanTestHelpers.js
+++ b/test/helpers/loanTestHelpers.js
@@ -78,7 +78,8 @@ async function createLoan(testInstance, product, borrower, collateralWei) {
             borrower: loan.borrower,
             collateralAmount: loan.collateralAmount.toString(),
             loanAmount: loan.loanAmount.toString(),
-            repaymentAmount: loan.repaymentAmount.toString()
+            repaymentAmount: loan.repaymentAmount.toString(),
+            maturity: x => x
         }),
 
         testHelpers.assertEvent(augmintToken, "AugmintTransfer", {
@@ -98,6 +99,7 @@ async function createLoan(testInstance, product, borrower, collateralWei) {
     ]);
 
     loan.id = newLoanEvenResult.loanId.toNumber();
+    loan.maturity = newLoanEvenResult.maturity.toNumber();
 
     const [totalSupplyAfter, totalLoanAmountAfter, ,] = await Promise.all([
         augmintToken.totalSupply(),

--- a/test/helpers/loanTestHelpers.js
+++ b/test/helpers/loanTestHelpers.js
@@ -196,8 +196,11 @@ async function repayLoan(testInstance, loan) {
 
     assert.equal(
         totalSupplyAfter.toString(),
-        totalSupplyBefore.sub(loan.loanAmount).toString(),
-        "total ACE supply should be reduced by the loan amount (what was disbursed)"
+        totalSupplyBefore
+            .sub(loan.repaymentAmount)
+            .add(loan.interestAmount)
+            .toString(),
+        "total supply should be reduced by the repayment amount less interestAmount"
     );
     assert.equal(
         totalLoanAmountAfter.toString(),
@@ -382,7 +385,10 @@ async function calcLoanValues(rates, product, collateralWei) {
         .div(ppmDiv * ppmDiv)
         .round(0, BigNumber.ROUND_DOWN);
 
-    ret.interestAmount = ret.repaymentAmount.minus(ret.loanAmount);
+    ret.interestAmount = ret.repaymentAmount.gt(ret.loanAmount)
+        ? ret.repaymentAmount.minus(ret.loanAmount)
+        : new BigNumber(0);
+
     ret.disbursementTime = moment()
         .utc()
         .unix();

--- a/test/helpers/loanTestHelpers.js
+++ b/test/helpers/loanTestHelpers.js
@@ -26,7 +26,7 @@ module.exports = {
     repayLoan,
     collectLoan,
     getProductsInfo,
-    getLoansInfo,
+    parseLoansInfo,
     calcLoanValues,
     loanAsserts,
     get loanManager() {
@@ -327,8 +327,8 @@ async function getProductsInfo(offset) {
     return result;
 }
 
-async function getLoansInfo(offset) {
-    const loans = await loanManager.getLoans(offset);
+/* parse array returned by getLoans & getLoansForAddress */
+function parseLoansInfo(loans) {
     assert.equal(loans.length, CHUNK_SIZE);
     const result = [];
     loans.map(loan => {

--- a/test/helpers/loanTestHelpers.js
+++ b/test/helpers/loanTestHelpers.js
@@ -348,30 +348,19 @@ async function calcLoanValues(rates, product, collateralWei) {
 
 async function loanAsserts(expLoan) {
     const loan = await loanManager.loans(expLoan.id);
-    assert.equal(loan[0], expLoan.borrower, "borrower should be set");
-    assert.equal(loan[1].toNumber(), expLoan.state, "loan state should be set");
-    assert.equal(loan[2].toString(), expLoan.collateral.toString(), "collateralAmount should be set");
-    assert.equal(loan[3].toString(), expLoan.repaymentAmount.toString(), "repaymentAmount should be set");
-    assert.equal(loan[4].toString(), expLoan.loanAmount.toString(), "loanAmount should be set");
-    assert.equal(loan[5].toString(), expLoan.interestAmount.toString(), "interestAmount should be set");
-    assert.equal(loan[6].toString(), expLoan.product.term.toString(), "term should be set");
+    assert.equal(loan[0].toString(), expLoan.collateral.toString(), "collateralAmount should be set");
+    assert.equal(loan[1].toString(), expLoan.repaymentAmount.toString(), "repaymentAmount should be set");
+    assert.equal(loan[2], expLoan.borrower, "borrower should be set");
+    assert.equal(loan[3].toNumber(), expLoan.product.id, "product id should be set");
+    assert.equal(loan[4].toNumber(), expLoan.state, "loan state should be set");
 
-    const disbursementTimeActual = loan[7];
+    const maturityActual = loan[5];
+    const maturityExpected = expLoan.product.term.add(expLoan.disbursementTime).toNumber();
+
+    assert(maturityActual >= maturityExpected, "maturity should be at least term + the time at disbursement");
     assert(
-        disbursementTimeActual >= expLoan.disbursementTime,
-        "disbursementDate should be at least the time at disbursement"
+        maturityActual <= maturityExpected + 5,
+        "maturity should be at most the term + time at disbursement + 5. Difference is: " +
+            (maturityActual - maturityExpected)
     );
-    assert(
-        disbursementTimeActual <= expLoan.disbursementTime + 5,
-        "disbursementDate should be at most the time at disbursement + 5. Difference is: " +
-            (disbursementTimeActual - expLoan.disbursementTime)
-    );
-
-    assert.equal(
-        loan[8].toString(),
-        disbursementTimeActual.add(expLoan.product.term),
-        "maturity should be at disbursementDate + term"
-    );
-
-    assert.equal(loan[9].toString(), expLoan.product.defaultingFeePt.toString(), "defaultingFeePt should be set");
 }

--- a/test/helpers/loanTestHelpers.js
+++ b/test/helpers/loanTestHelpers.js
@@ -309,10 +309,10 @@ async function getProductInfo(productId) {
     const prod = await loanManager.products(productId);
     const info = {
         id: productId,
-        term: prod[0],
-        discountRate: prod[1],
-        collateralRatio: prod[2],
-        minDisbursedAmount: prod[3],
+        minDisbursedAmount: prod[0],
+        term: prod[1],
+        discountRate: prod[2],
+        collateralRatio: prod[3],
         defaultingFeePt: prod[4],
         isActive: prod[5]
     };

--- a/test/loanCollection.js
+++ b/test/loanCollection.js
@@ -21,12 +21,20 @@ contract("Loans tests", accounts => {
         await loanManager.addLoanProduct(86400, 970000, 850000, 3000, 50000, true); // notDue
         await loanManager.addLoanProduct(1, 970000, 850000, 1000, 50000, true); // defaulting
         await loanManager.addLoanProduct(1, 900000, 900000, 1000, 100000, true); // defaultingNoLeftOver
+        await loanManager.addLoanProduct(1, 1000000, 900000, 2000, 50000, true); // zeroInterest
+        await loanManager.addLoanProduct(1, 1100000, 900000, 2000, 50000, true); // negativeInterest
 
         const [newProducts] = await Promise.all([
             loanTestHelpers.getProductsInfo(prodCount),
             tokenTestHelpers.withdrawFromReserve(accounts[0], 1000000000)
         ]);
-        [products.notDue, products.defaulting, products.defaultingNoLeftOver] = newProducts;
+        [
+            products.notDue,
+            products.defaulting,
+            products.defaultingNoLeftOver,
+            products.zeroInterest,
+            products.negativeInterest
+        ] = newProducts;
     });
 
     it("Should collect a defaulted A-EUR loan and send back leftover collateral ", async function() {
@@ -64,8 +72,15 @@ contract("Loans tests", accounts => {
         await rates.setRate("EUR", 99800); // restore rates
     });
 
-    it("Should get and collect a loan with colletaralRatio = 1");
-    it("Should get and collect a loan with colletaralRatio > 1");
+    it("Should get and collect a loan with colletaralRatio = 1", async function() {
+        const loan = await loanTestHelpers.createLoan(this, products.zeroInterest, accounts[0], web3.toWei(0.5));
+        await loanTestHelpers.collectLoan(this, loan, accounts[2]);
+    });
+
+    it("Should get and collect a loan with colletaralRatio > 1", async function() {
+        const loan = await loanTestHelpers.createLoan(this, products.negativeInterest, accounts[0], web3.toWei(0.5));
+        await loanTestHelpers.collectLoan(this, loan, accounts[2]);
+    });
 
     it("Should collect multiple defaulted A-EUR loans ");
 

--- a/test/loanCollection.js
+++ b/test/loanCollection.js
@@ -1,0 +1,98 @@
+const testHelpers = require("./helpers/testHelpers.js");
+const tokenTestHelpers = require("./helpers/tokenTestHelpers.js");
+const loanTestHelpers = require("./helpers/loanTestHelpers.js");
+const ratesTestHelpers = require("./helpers/ratesTestHelpers.js");
+
+let loanManager = null;
+let monetarySupervisor = null;
+let rates = null;
+let products = {};
+
+contract("Loans tests", accounts => {
+    before(async function() {
+        rates = ratesTestHelpers.rates;
+        monetarySupervisor = tokenTestHelpers.monetarySupervisor;
+        loanManager = loanTestHelpers.loanManager;
+        await tokenTestHelpers.issueToReserve(1000000000);
+
+        const prodCount = (await loanManager.getProductCount()).toNumber();
+        // These neeed to be sequantial b/c product order assumed when retreving via getProducts
+        // term (in sec), discountRate, loanCoverageRatio, minDisbursedAmount (w/ 2 decimals), defaultingFeePt, isActive
+        await loanManager.addLoanProduct(86400, 970000, 850000, 3000, 50000, true); // notDue
+        await loanManager.addLoanProduct(1, 970000, 850000, 1000, 50000, true); // defaulting
+        await loanManager.addLoanProduct(1, 900000, 900000, 1000, 100000, true); // defaultingNoLeftOver
+
+        const [newProducts] = await Promise.all([
+            loanTestHelpers.getProductsInfo(prodCount),
+            tokenTestHelpers.withdrawFromReserve(accounts[0], 1000000000)
+        ]);
+        [products.notDue, products.defaulting, products.defaultingNoLeftOver] = newProducts;
+    });
+
+    it("Should collect a defaulted A-EUR loan and send back leftover collateral ", async function() {
+        const loan = await loanTestHelpers.createLoan(this, products.defaulting, accounts[1], web3.toWei(0.5));
+
+        await testHelpers.waitForTimeStamp(loan.maturity);
+
+        await loanTestHelpers.collectLoan(this, loan, accounts[2]);
+    });
+
+    it("Should collect a defaulted A-EUR loan when no leftover collateral (collection exactly covered)", async function() {
+        await rates.setRate("EUR", 100000);
+        const loan = await loanTestHelpers.createLoan(this, products.defaultingNoLeftOver, accounts[1], web3.toWei(1));
+
+        await Promise.all([rates.setRate("EUR", 99000), testHelpers.waitForTimeStamp(loan.maturity)]);
+
+        await loanTestHelpers.collectLoan(this, loan, accounts[2]);
+    });
+
+    it("Should collect a defaulted A-EUR loan when no leftover collateral (collection partially covered)", async function() {
+        await rates.setRate("EUR", 100000);
+        const loan = await loanTestHelpers.createLoan(this, products.defaultingNoLeftOver, accounts[1], web3.toWei(1));
+
+        await Promise.all([rates.setRate("EUR", 98900), testHelpers.waitForTimeStamp(loan.maturity)]);
+
+        await loanTestHelpers.collectLoan(this, loan, accounts[2]);
+    });
+
+    it("Should collect a defaulted A-EUR loan when no leftover collateral (only fee covered)", async function() {
+        await rates.setRate("EUR", 99800);
+        const loan = await loanTestHelpers.createLoan(this, products.defaultingNoLeftOver, accounts[1], web3.toWei(2));
+        await Promise.all([rates.setRate("EUR", 1), testHelpers.waitForTimeStamp(loan.maturity)]);
+
+        await loanTestHelpers.collectLoan(this, loan, accounts[2]);
+        await rates.setRate("EUR", 99800); // restore rates
+    });
+
+    it("Should get and collect a loan with colletaralRatio = 1");
+    it("Should get and collect a loan with colletaralRatio > 1");
+
+    it("Should collect multiple defaulted A-EUR loans ");
+
+    it("Should NOT collect a loan before it's due", async function() {
+        const loan = await loanTestHelpers.createLoan(this, products.notDue, accounts[1], web3.toWei(0.5));
+        await testHelpers.expectThrow(loanManager.collect([loan.id]));
+    });
+
+    it("Should not collect when rate = 0", async function() {
+        await rates.setRate("EUR", 99800);
+        const loan = await loanTestHelpers.createLoan(this, products.defaultingNoLeftOver, accounts[1], web3.toWei(2));
+        await Promise.all([rates.setRate("EUR", 0), testHelpers.waitForTimeStamp(loan.maturity)]);
+
+        testHelpers.expectThrow(loanTestHelpers.collectLoan(this, loan, accounts[2]));
+        await rates.setRate("EUR", 99800);
+    });
+
+    it("Should NOT collect an already collected loan", async function() {
+        const loan = await loanTestHelpers.createLoan(this, products.defaulting, accounts[1], web3.toWei(0.5));
+
+        await testHelpers.waitForTimeStamp(loan.maturity);
+
+        await loanTestHelpers.collectLoan(this, loan, accounts[2]);
+        await testHelpers.expectThrow(loanManager.collect([loan.id]));
+    });
+
+    it("only allowed contract should call MonetarySupervisor.loanCollectionNotification", async function() {
+        await testHelpers.expectThrow(monetarySupervisor.loanCollectionNotification(0, { from: accounts[0] }));
+    });
+});

--- a/test/loans.js
+++ b/test/loans.js
@@ -78,7 +78,7 @@ contract("Augmint Loans tests", accounts => {
     it("Should collect a defaulted A-EUR loan and send back leftover collateral ", async function() {
         const loan = await loanTestHelpers.createLoan(this, products.defaulting, accounts[1], web3.toWei(0.5));
 
-        await testHelpers.waitForTimeStamp(loan.product.term.add(loan.disbursementTime).toNumber());
+        await testHelpers.waitForTimeStamp(loan.maturity);
 
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
@@ -87,10 +87,7 @@ contract("Augmint Loans tests", accounts => {
         await rates.setRate("EUR", 100000);
         const loan = await loanTestHelpers.createLoan(this, products.defaultingNoLeftOver, accounts[1], web3.toWei(1));
 
-        await Promise.all([
-            rates.setRate("EUR", 99000),
-            testHelpers.waitForTimeStamp(loan.product.term.add(loan.disbursementTime).toNumber())
-        ]);
+        await Promise.all([rates.setRate("EUR", 99000), testHelpers.waitForTimeStamp(loan.maturity)]);
 
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
@@ -99,10 +96,7 @@ contract("Augmint Loans tests", accounts => {
         await rates.setRate("EUR", 100000);
         const loan = await loanTestHelpers.createLoan(this, products.defaultingNoLeftOver, accounts[1], web3.toWei(1));
 
-        await Promise.all([
-            rates.setRate("EUR", 98900),
-            testHelpers.waitForTimeStamp(loan.product.term.add(loan.disbursementTime).toNumber())
-        ]);
+        await Promise.all([rates.setRate("EUR", 98900), testHelpers.waitForTimeStamp(loan.maturity)]);
 
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
@@ -110,10 +104,7 @@ contract("Augmint Loans tests", accounts => {
     it("Should collect a defaulted A-EUR loan when no leftover collateral (only fee covered)", async function() {
         await rates.setRate("EUR", 99800);
         const loan = await loanTestHelpers.createLoan(this, products.defaultingNoLeftOver, accounts[1], web3.toWei(2));
-        await Promise.all([
-            rates.setRate("EUR", 1),
-            testHelpers.waitForTimeStamp(loan.product.term.add(loan.disbursementTime).toNumber())
-        ]);
+        await Promise.all([rates.setRate("EUR", 1), testHelpers.waitForTimeStamp(loan.maturity)]);
 
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
@@ -121,10 +112,7 @@ contract("Augmint Loans tests", accounts => {
     it("Should not collect when rate = 0", async function() {
         await rates.setRate("EUR", 99800);
         const loan = await loanTestHelpers.createLoan(this, products.defaultingNoLeftOver, accounts[1], web3.toWei(2));
-        await Promise.all([
-            rates.setRate("EUR", 0),
-            testHelpers.waitForTimeStamp(loan.product.term.add(loan.disbursementTime).toNumber())
-        ]);
+        await Promise.all([rates.setRate("EUR", 0), testHelpers.waitForTimeStamp(loan.maturity)]);
 
         testHelpers.expectThrow(loanTestHelpers.collectLoan(this, loan, accounts[2]));
     });

--- a/test/loans.js
+++ b/test/loans.js
@@ -29,6 +29,8 @@ contract("Loans tests", accounts => {
         await loanManager.addLoanProduct(1, 990000, 990000, 1000, 50000, false); // disabledProduct
         await loanManager.addLoanProduct(60, 1000000, 900000, 2000, 50000, true); // zeroInterest
         await loanManager.addLoanProduct(60, 1100000, 900000, 2000, 50000, true); // negativeInterest
+        await loanManager.addLoanProduct(60, 990000, 1000000, 2000, 50000, true); // fullCoverage
+        await loanManager.addLoanProduct(60, 990000, 1200000, 2000, 50000, true); // moreCoverage
 
         const [newProducts] = await Promise.all([
             loanTestHelpers.getProductsInfo(prodCount),
@@ -40,7 +42,9 @@ contract("Loans tests", accounts => {
             products.defaulting,
             products.disabledProduct,
             products.zeroInterest,
-            products.negativeInterest
+            products.negativeInterest,
+            products.fullCoverage,
+            products.moreCoverage
         ] = newProducts;
     });
 
@@ -75,17 +79,27 @@ contract("Loans tests", accounts => {
         await augmintToken.transfer(loan.borrower, loan.interestAmount, {
             from: accounts[0]
         });
-        await loanTestHelpers.repayLoan(this, loan, true);
+        await loanTestHelpers.repayLoan(this, loan);
     });
 
     it("Should get and repay a loan whith discountRate = 1 (zero interest)", async function() {
         const loan = await loanTestHelpers.createLoan(this, products.zeroInterest, accounts[0], web3.toWei(0.5));
-        await loanTestHelpers.repayLoan(this, loan, true);
+        await loanTestHelpers.repayLoan(this, loan);
     });
 
     it("Should get and repay a loan whith discountRate > 1 (negative interest)", async function() {
         const loan = await loanTestHelpers.createLoan(this, products.negativeInterest, accounts[0], web3.toWei(0.5));
-        await loanTestHelpers.repayLoan(this, loan, true);
+        await loanTestHelpers.repayLoan(this, loan);
+    });
+
+    it("Should get and repay a loan with colletaralRatio = 1", async function() {
+        const loan = await loanTestHelpers.createLoan(this, products.fullCoverage, accounts[0], web3.toWei(0.5));
+        await loanTestHelpers.repayLoan(this, loan);
+    });
+
+    it("Should get and repay a loan with colletaralRatio > 1", async function() {
+        const loan = await loanTestHelpers.createLoan(this, products.moreCoverage, accounts[0], web3.toWei(0.5));
+        await loanTestHelpers.repayLoan(this, loan);
     });
 
     it("Non owner should be able to repay a loan too", async function() {
@@ -214,9 +228,6 @@ contract("Loans tests", accounts => {
         assert.equal(lastLoan.loanAmount.toNumber(), loan.loanAmount);
         assert.equal(lastLoan.interestAmount.toNumber(), loan.interestAmount);
     });
-
-    it("Should get and repay a loan with colletaralRatio = 1");
-    it("Should get and repay a loan with colletaralRatio > 1");
 
     it("should only allow whitelisted loan contract to be used", async function() {
         const interestEarnedAcc = await monetarySupervisor.interestEarnedAccount();

--- a/test/loans.js
+++ b/test/loans.js
@@ -52,7 +52,7 @@ contract("Augmint Loans tests", accounts => {
         ]);
     });
 
-    it("Should get an ACE loan", async function() {
+    it("Should get an A-EUR loan", async function() {
         await loanTestHelpers.createLoan(this, products.repaying, accounts[0], web3.toWei(0.5));
     });
 
@@ -65,21 +65,21 @@ contract("Augmint Loans tests", accounts => {
     });
 
     it("Should NOT collect a loan before it's due");
-    it("Should NOT repay an ACE loan on maturity if ACE balance is insufficient");
+    it("Should NOT repay an A-EUR loan on maturity if A-EUR balance is insufficient");
     it("should not repay a loan with smaller amount than repaymentAmount");
     it("Non owner should be able to repay a loan too");
     it("Should not repay with invalid loanId");
 
-    it("Should repay an ACE loan before maturity", async function() {
+    it("Should repay an A-EUR loan before maturity", async function() {
         const loan = await loanTestHelpers.createLoan(this, products.notDue, accounts[1], web3.toWei(0.5));
-        // send interest to borrower to have enough ACE to repay in test
+        // send interest to borrower to have enough A-EUR to repay in test
         await augmintToken.transfer(loan.borrower, loan.interestAmount, {
             from: accounts[0]
         });
         await loanTestHelpers.repayLoan(this, loan, true); // repaymant via AugmintToken.repayLoan convenience func
     });
 
-    it("Should collect a defaulted ACE loan and send back leftover collateral ", async function() {
+    it("Should collect a defaulted A-EUR loan and send back leftover collateral ", async function() {
         const loan = await loanTestHelpers.createLoan(this, products.defaulting, accounts[1], web3.toWei(0.5));
 
         await testHelpers.waitForTimeStamp(loan.product.term.add(loan.disbursementTime).toNumber());
@@ -87,7 +87,7 @@ contract("Augmint Loans tests", accounts => {
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
 
-    it("Should collect a defaulted ACE loan when no leftover collateral (collection exactly covered)", async function() {
+    it("Should collect a defaulted A-EUR loan when no leftover collateral (collection exactly covered)", async function() {
         await rates.setRate("EUR", 100000);
         const loan = await loanTestHelpers.createLoan(this, products.defaultingNoLeftOver, accounts[1], web3.toWei(1));
 
@@ -99,7 +99,7 @@ contract("Augmint Loans tests", accounts => {
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
 
-    it("Should collect a defaulted ACE loan when no leftover collateral (collection partially covered)", async function() {
+    it("Should collect a defaulted A-EUR loan when no leftover collateral (collection partially covered)", async function() {
         await rates.setRate("EUR", 100000);
         const loan = await loanTestHelpers.createLoan(this, products.defaultingNoLeftOver, accounts[1], web3.toWei(1));
 
@@ -111,7 +111,7 @@ contract("Augmint Loans tests", accounts => {
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
 
-    it("Should collect a defaulted ACE loan when no leftover collateral (only fee covered)", async function() {
+    it("Should collect a defaulted A-EUR loan when no leftover collateral (only fee covered)", async function() {
         await rates.setRate("EUR", 99800);
         const loan = await loanTestHelpers.createLoan(this, products.defaultingNoLeftOver, accounts[1], web3.toWei(2));
         await Promise.all([
@@ -138,9 +138,9 @@ contract("Augmint Loans tests", accounts => {
 
     it("Should NOT repay a loan after paymentperiod is over");
 
-    it("Should NOT collect an already collected ACE loan");
+    it("Should NOT collect an already collected A-EUR loan");
 
-    it("Should collect multiple defaulted ACE loans ");
+    it("Should collect multiple defaulted A-EUR loans ");
 
     it("Should get and repay a loan with colletaralRatio = 1");
     it("Should get and repay a loan with colletaralRatio > 1");

--- a/test/loans.js
+++ b/test/loans.js
@@ -123,7 +123,11 @@ contract("Augmint Loans tests", accounts => {
 
         const loan = await loanTestHelpers.createLoan(this, product, accounts[1], web3.toWei(2));
 
-        const loanInfo = await loanTestHelpers.getLoansInfo(loan.id);
+        const loansArray = await loanManager.getLoans(loan.id);
+        const loanInfo = loanTestHelpers.parseLoansInfo(loansArray);
+
+        assert.equal(loanInfo.length, 1); // offset was from last loan added
+
         const lastLoan = loanInfo[0];
 
         assert.equal(lastLoan.id.toNumber(), loan.id);
@@ -138,7 +142,30 @@ contract("Augmint Loans tests", accounts => {
         assert.equal(lastLoan.interestAmount.toNumber(), loan.interestAmount);
     });
 
-    it("Should get loans for one account from offset"); // contract func to be implemented
+    it("Should list loans for one account from offset", async function() {
+        const product = products.repaying;
+        const borrower = accounts[1];
+
+        const loan = await loanTestHelpers.createLoan(this, product, borrower, web3.toWei(2));
+        const accountLoanCount = await loanManager.getLoanCountForAddress(borrower);
+
+        const loansArray = await loanManager.getLoansForAddress(borrower, accountLoanCount - 1);
+        const loanInfo = loanTestHelpers.parseLoansInfo(loansArray);
+        assert.equal(loanInfo.length, 1); // offset was from last loan added for account
+
+        const lastLoan = loanInfo[0];
+
+        assert.equal(lastLoan.id.toNumber(), loan.id);
+        assert.equal(lastLoan.collateralAmount.toNumber(), loan.collateralAmount);
+        assert.equal(lastLoan.repaymentAmount.toNumber(), loan.repaymentAmount);
+        assert.equal("0x" + lastLoan.borrower.toString(16), loan.borrower);
+        assert.equal(lastLoan.productId.toNumber(), product.id);
+        assert.equal(lastLoan.state.toNumber(), loan.state);
+        assert.equal(lastLoan.maturity.toNumber(), loan.maturity);
+        assert.equal(lastLoan.disbursementTime.toNumber(), loan.maturity - product.term);
+        assert.equal(lastLoan.loanAmount.toNumber(), loan.loanAmount);
+        assert.equal(lastLoan.interestAmount.toNumber(), loan.interestAmount);
+    });
 
     it("Should NOT repay a loan after paymentperiod is over");
 

--- a/test/loans.js
+++ b/test/loans.js
@@ -35,21 +35,17 @@ contract("Augmint Loans tests", accounts => {
         // disabled product
         await loanManager.addLoanProduct(1, 990000, 990000, 1000, 50000, false);
 
-        [
-            products.disabledProduct,
-            products.defaultingNoLeftOver,
-            products.defaulting,
-            products.repaying,
-            products.notDue,
-            ,
-        ] = await Promise.all([
-            loanTestHelpers.getProductInfo(prodCount + 4),
-            loanTestHelpers.getProductInfo(prodCount + 3),
-            loanTestHelpers.getProductInfo(prodCount + 2),
-            loanTestHelpers.getProductInfo(prodCount + 1),
-            loanTestHelpers.getProductInfo(prodCount),
+        const [newProducts] = await Promise.all([
+            loanTestHelpers.getProductsInfo(prodCount),
             tokenTestHelpers.withdrawFromReserve(accounts[0], 1000000000)
         ]);
+        [
+            products.notDue,
+            products.repaying,
+            products.defaulting,
+            products.defaultingNoLeftOver,
+            products.disabledProduct
+        ] = newProducts;
     });
 
     it("Should get an A-EUR loan", async function() {

--- a/test/loans.js
+++ b/test/loans.js
@@ -82,7 +82,7 @@ contract("Augmint Loans tests", accounts => {
     it("Should collect a defaulted ACE loan and send back leftover collateral ", async function() {
         const loan = await loanTestHelpers.createLoan(this, products.defaulting, accounts[1], web3.toWei(0.5));
 
-        await testHelpers.waitForTimeStamp((await loanManager.loans(loan.id))[8].toNumber());
+        await testHelpers.waitForTimeStamp(loan.product.term.add(loan.disbursementTime).toNumber());
 
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
@@ -93,7 +93,7 @@ contract("Augmint Loans tests", accounts => {
 
         await Promise.all([
             rates.setRate("EUR", 99000),
-            testHelpers.waitForTimeStamp((await loanManager.loans(loan.id))[8].toNumber())
+            testHelpers.waitForTimeStamp(loan.product.term.add(loan.disbursementTime).toNumber())
         ]);
 
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
@@ -105,7 +105,7 @@ contract("Augmint Loans tests", accounts => {
 
         await Promise.all([
             rates.setRate("EUR", 98900),
-            testHelpers.waitForTimeStamp((await loanManager.loans(loan.id))[8].toNumber())
+            testHelpers.waitForTimeStamp(loan.product.term.add(loan.disbursementTime).toNumber())
         ]);
 
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
@@ -116,7 +116,7 @@ contract("Augmint Loans tests", accounts => {
         const loan = await loanTestHelpers.createLoan(this, products.defaultingNoLeftOver, accounts[1], web3.toWei(2));
         await Promise.all([
             rates.setRate("EUR", 1),
-            testHelpers.waitForTimeStamp((await loanManager.loans(loan.id))[8].toNumber())
+            testHelpers.waitForTimeStamp(loan.product.term.add(loan.disbursementTime).toNumber())
         ]);
 
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
@@ -127,7 +127,7 @@ contract("Augmint Loans tests", accounts => {
         const loan = await loanTestHelpers.createLoan(this, products.defaultingNoLeftOver, accounts[1], web3.toWei(2));
         await Promise.all([
             rates.setRate("EUR", 0),
-            testHelpers.waitForTimeStamp((await loanManager.loans(loan.id))[8].toNumber())
+            testHelpers.waitForTimeStamp(loan.product.term.add(loan.disbursementTime).toNumber())
         ]);
 
         testHelpers.expectThrow(loanTestHelpers.collectLoan(this, loan, accounts[2]));

--- a/test/loans.js
+++ b/test/loans.js
@@ -115,9 +115,29 @@ contract("Augmint Loans tests", accounts => {
         await Promise.all([rates.setRate("EUR", 0), testHelpers.waitForTimeStamp(loan.maturity)]);
 
         testHelpers.expectThrow(loanTestHelpers.collectLoan(this, loan, accounts[2]));
+        await rates.setRate("EUR", 99800);
     });
 
-    it("Should get loans from offset"); // contract func to be implemented
+    it("Should list loans from offset", async function() {
+        const product = products.repaying;
+
+        const loan = await loanTestHelpers.createLoan(this, product, accounts[1], web3.toWei(2));
+
+        const loanInfo = await loanTestHelpers.getLoansInfo(loan.id);
+        const lastLoan = loanInfo[0];
+
+        assert.equal(lastLoan.id.toNumber(), loan.id);
+        assert.equal(lastLoan.collateralAmount.toNumber(), loan.collateralAmount);
+        assert.equal(lastLoan.repaymentAmount.toNumber(), loan.repaymentAmount);
+        assert.equal("0x" + lastLoan.borrower.toString(16), loan.borrower);
+        assert.equal(lastLoan.productId.toNumber(), product.id);
+        assert.equal(lastLoan.state.toNumber(), loan.state);
+        assert.equal(lastLoan.maturity.toNumber(), loan.maturity);
+        assert.equal(lastLoan.disbursementTime.toNumber(), loan.maturity - product.term);
+        assert.equal(lastLoan.loanAmount.toNumber(), loan.loanAmount);
+        assert.equal(lastLoan.interestAmount.toNumber(), loan.interestAmount);
+    });
+
     it("Should get loans for one account from offset"); // contract func to be implemented
 
     it("Should NOT repay a loan after paymentperiod is over");

--- a/truffle.js
+++ b/truffle.js
@@ -14,7 +14,7 @@ module.exports = {
             port: 8545,
             network_id: "999",
             gas: 4707806,
-            gasPrice: 1
+            gasPrice: 1000000000 // 1 GWEI
         },
         truffleLocal: {
             host: "localhost",
@@ -34,7 +34,7 @@ module.exports = {
             from: "0xae653250B4220835050B75D3bC91433246903A95", // default address to use for any transaction Truffle makes during migrations
             network_id: 4,
             gas: 4700000, // Gas limit used for deploys
-            gasPrice: 20000000000 // 20 Gwei
+            gasPrice: 1000000000 // 1 Gwei
         },
         ropsten: {
             host: "localhost", // Connect to geth on the specified


### PR DESCRIPTION
- refactor storage. Changes reduced gas costs:
  - first new loan:  306,555 to 197,196
  - consecutive new loan: 291,574 to 167,196
  - first repay: 106,534 to 105,354
  - cons. repay: ?
  - first collect:  73,333 to 71,695
  - cons. collect: 64,683 to 63,620
- new UI helper fx-s:
  - `getLoans(offset)`
  - `getLoanCountForAddress(borrower)` & `getLoansForAddress(borrower, offset)` 
- using div instead of roundedDiv for loan calculations - attempt to simplify UI calculations too as we don't need roundedDiv here (unlike on exchange orderfills)
- allow zero or negative interest on loans (discountRate >= 1)
- split Defaulted loan state into Defaulted (not stored, returned only via getters) and Collected
- finished pending unit tests