### PR TITLE
Audit multisig

### DIFF
--- a/contracts/generic/MultiSig.sol
+++ b/contracts/generic/MultiSig.sol
@@ -94,7 +94,9 @@ contract MultiSig {
         script.state = ScriptState.Failed;
 
         // passing scriptAddress to allow called script access its own public fx-s if needed
-        if (scriptAddress.delegatecall(abi.encodeWithSignature("execute(address)", scriptAddress))) {
+        // TODO: figure out exactly how much gas we want to retain from delegatecall
+        if (scriptAddress.delegatecall.gas(gasleft() - 10000)
+            (abi.encodeWithSignature("execute(address)", scriptAddress))) {
             script.state = ScriptState.Done;
             result = true;
         } else {

--- a/contracts/generic/MultiSig.sol
+++ b/contracts/generic/MultiSig.sol
@@ -94,8 +94,7 @@ contract MultiSig {
         script.state = ScriptState.Failed;
 
         // passing scriptAddress to allow called script access its own public fx-s if needed
-        // TODO: figure out exactly how much gas we want to retain from delegatecall
-        if (scriptAddress.delegatecall.gas(gasleft() - 10000)
+        if (scriptAddress.delegatecall.gas(gasleft() - 23000)
             (abi.encodeWithSignature("execute(address)", scriptAddress))) {
             script.state = ScriptState.Done;
             result = true;

--- a/contracts/generic/MultiSig.sol
+++ b/contracts/generic/MultiSig.sol
@@ -94,7 +94,7 @@ contract MultiSig {
         script.state = ScriptState.Failed;
 
         // passing scriptAddress to allow called script access its own public fx-s if needed
-        if(scriptAddress.delegatecall(bytes4(keccak256("execute(address)")), scriptAddress)) {
+        if (scriptAddress.delegatecall(abi.encodeWithSignature("execute(address)", scriptAddress))) {
             script.state = ScriptState.Done;
             result = true;
         } else {


### PR DESCRIPTION
Fixes #.10 and #.11 in MultiSig

- use abi.encodeWithSignature for delegatecall
- limit gas amount sent to delegatecall