### PR TITLE
Audit withdraw

### DIFF
--- a/contracts/AugmintReserves.sol
+++ b/contracts/AugmintReserves.sol
@@ -12,16 +12,27 @@ import "./generic/SystemAccount.sol";
 import "./interfaces/AugmintTokenInterface.sol";
 
 
-contract AugmintReserves is SystemAccount {
+contract AugmintReserves is Restricted {
+
+    event ReserveMigration(address to, uint weiAmount);
 
     constructor(address permissionGranterContract)
-    public SystemAccount(permissionGranterContract) {} // solhint-disable-line no-empty-blocks
+    public Restricted(permissionGranterContract) {} // solhint-disable-line no-empty-blocks
 
     function () external payable { // solhint-disable-line no-empty-blocks
         // to accept ETH sent into reserve (from defaulted loan's collateral )
     }
 
-    function burn(AugmintTokenInterface augmintToken, uint amount) external restrict("MonetarySupervisor") {
+    function burn(AugmintTokenInterface augmintToken, uint amount)
+    external restrict("MonetarySupervisor") {
         augmintToken.burn(amount);
+    }
+
+    function migrate(address to, uint weiAmount)
+    external restrict("StabilityBoard") {
+        if (weiAmount > 0) {
+            to.transfer(weiAmount);
+        }
+        emit ReserveMigration(to, weiAmount);
     }
 }

--- a/contracts/generic/SystemAccount.sol
+++ b/contracts/generic/SystemAccount.sol
@@ -8,18 +8,15 @@ contract SystemAccount is Restricted {
     event WithdrawFromSystemAccount(address tokenAddress, address to, uint tokenAmount, uint weiAmount,
                                     string narrative);
 
-    constructor(address permissionGranterContract) public Restricted(permissionGranterContract) {} // solhint-disable-line no-empty-blocks
+    constructor(address permissionGranterContract)
+    public Restricted(permissionGranterContract) {} // solhint-disable-line no-empty-blocks
 
-    /* TODO: this is only for first pilots to avoid funds stuck in contract due to bugs.
-      remove this function for higher volume pilots */
     function withdraw(AugmintToken tokenAddress, address to, uint tokenAmount, uint weiAmount, string narrative)
     external restrict("StabilityBoard") {
         tokenAddress.transferWithNarrative(to, tokenAmount, narrative);
         if (weiAmount > 0) {
             to.transfer(weiAmount);
         }
-
         emit WithdrawFromSystemAccount(tokenAddress, to, tokenAmount, weiAmount, narrative);
     }
-
 }

--- a/test/delegatedTransfer.js
+++ b/test/delegatedTransfer.js
@@ -94,8 +94,7 @@ contract("Delegated Transfers", accounts => {
         from = accounts[1];
         tokenAEur = new global.web3v1.eth.Contract(TokenAEur.abi, TokenAEur.address);
 
-        await tokenTestHelpers.issueToReserve(100000);
-        await tokenTestHelpers.withdrawFromReserve(from, 100000);
+        await tokenTestHelpers.issueToken(accounts[0], from, 10000);
     });
 
     it("should transfer when delegatedTransfer is signed", async function() {

--- a/test/delegatedTransferAndNotify.js
+++ b/test/delegatedTransferAndNotify.js
@@ -88,10 +88,10 @@ contract("Delegated transferAndNotify", accounts => {
         tokenAEur = new global.web3v1.eth.Contract(TokenAEur.abi, TokenAEur.address);
 
         const lockerInstance = Locker.at(Locker.address);
-        const [product] = await Promise.all([lockerInstance.lockProducts(0), tokenTestHelpers.issueToReserve(100000)]);
+        const product = await lockerInstance.lockProducts(0);
         perTermInterest = product[0].toNumber();
 
-        await tokenTestHelpers.withdrawFromReserve(from, 100000);
+        await tokenTestHelpers.issueToken(accounts[0], from, 10000);
     });
 
     it("should lock with delegatedTransferAndNotify", async function() {

--- a/test/exchangeMatching.js
+++ b/test/exchangeMatching.js
@@ -15,10 +15,8 @@ contract("Exchange matching tests", () => {
         exchange = exchangeTestHelper.exchange;
         maker = global.accounts[1];
         taker = global.accounts[2];
-
-        await tokenTestHelpers.issueToReserve(10000000);
-        await tokenTestHelpers.withdrawFromReserve(maker, 1000000);
-        await tokenTestHelpers.withdrawFromReserve(taker, 1000000);
+        await tokenTestHelpers.issueToken(global.accounts[0], maker, 1000000);
+        await tokenTestHelpers.issueToken(global.accounts[0], taker, 1000000);
     });
 
     beforeEach(async function() {

--- a/test/exchangeOrders.js
+++ b/test/exchangeOrders.js
@@ -18,10 +18,7 @@ contract("Exchange orders tests", accounts => {
         makers = [global.accounts[1], global.accounts[2]];
         exchange = exchangeTestHelpers.exchange;
         augmintToken = tokenTestHelpers.augmintToken;
-
-        await tokenTestHelpers.issueToReserve(10000000);
-
-        await Promise.all(makers.map(maker => tokenTestHelpers.withdrawFromReserve(maker, 1000000)));
+        await Promise.all(makers.map(maker => tokenTestHelpers.issueToken(accounts[0], maker, 1000000)));
     });
 
     beforeEach(async function() {

--- a/test/exchangeRandom.js
+++ b/test/exchangeRandom.js
@@ -71,12 +71,10 @@ contract("Exchange random tests", accounts => {
         augmintToken = tokenTestHelpers.augmintToken;
         const rates = Rates.at(Rates.address);
 
-        await tokenTestHelpers.issueToReserve(TEST_ACCS_CT * ACC_INIT_ACE);
-
         console.log(`\x1b[2m\t*** Topping up ${TEST_ACCS_CT} accounts each with ${ACC_INIT_ACE / 100} A-EURO\x1b[0m`);
         await Promise.all([
             rates.setRate("EUR", MARKET_EURETH_RATE),
-            accounts.slice(0, TEST_ACCS_CT).map(acc => tokenTestHelpers.withdrawFromReserve(acc, ACC_INIT_ACE))
+            accounts.slice(0, TEST_ACCS_CT).map(acc => tokenTestHelpers.issueToken(accounts[0], acc, ACC_INIT_ACE))
         ]);
     });
 

--- a/test/feeAccount.js
+++ b/test/feeAccount.js
@@ -45,9 +45,7 @@ contract("FeeAccount tests", accounts => {
         });
 
         // top up feeAccount with tokens
-        await tokenTestHelpers.issueToReserve(tokenAmount);
-        await tokenTestHelpers.withdrawFromReserve(accounts[0], tokenAmount);
-        await augmintTokenInstance.transfer(feeAccountInstance.address, tokenAmount);
+        await tokenTestHelpers.issueToken(accounts[0], feeAccountInstance.address, tokenAmount);
 
         const balBefore = await tokenTestHelpers.getAllBalances({
             to: accounts[0],

--- a/test/helpers/tokenTestHelpers.js
+++ b/test/helpers/tokenTestHelpers.js
@@ -10,8 +10,7 @@ const FeeAccount = artifacts.require("./FeeAccount.sol");
 const TRANSFER_MAX_GAS = 100000;
 
 module.exports = {
-    issueToReserve,
-    withdrawFromReserve,
+    issueToken,
     transferTest,
     getTransferFee,
     getAllBalances,
@@ -49,7 +48,7 @@ let augmintReserves = null;
 let monetarySupervisor = null;
 let peggedSymbol = null;
 let interestEarnedAccount = null;
-let feeAccount;
+let feeAccount = null;
 
 before(async function() {
     augmintToken = AugmintToken.at(AugmintToken.address);
@@ -63,12 +62,10 @@ before(async function() {
     peggedSymbol = global.web3v1.utils.toAscii(await augmintToken.peggedSymbol());
 });
 
-async function issueToReserve(amount) {
-    await monetarySupervisor.issueToReserve(amount);
-}
-
-async function withdrawFromReserve(to, amount) {
-    await augmintReserves.withdraw(augmintToken.address, to, amount, 0, "withdrawal for tests");
+async function issueToken(sender, to, amount) {
+    await augmintToken.grantPermission(sender, "MonetarySupervisor");
+    await augmintToken.issueTo(to, amount);
+    await augmintToken.revokePermission(sender, "MonetarySupervisor");
 }
 
 async function transferTest(testInstance, expTransfer) {

--- a/test/loanCollection.js
+++ b/test/loanCollection.js
@@ -14,7 +14,6 @@ contract("Loans collection tests", accounts => {
         rates = ratesTestHelpers.rates;
         monetarySupervisor = tokenTestHelpers.monetarySupervisor;
         loanManager = loanTestHelpers.loanManager;
-        await tokenTestHelpers.issueToReserve(1000000000);
 
         const [prodCount] = await Promise.all([
             loanManager.getProductCount().then(res => res.toNumber()),
@@ -36,7 +35,7 @@ contract("Loans collection tests", accounts => {
 
         const [newProducts] = await Promise.all([
             loanTestHelpers.getProductsInfo(prodCount, 10),
-            tokenTestHelpers.withdrawFromReserve(accounts[0], 1000000000)
+            tokenTestHelpers.issueToken(accounts[0], accounts[0], 1000000000)
         ]);
         [
             products.notDue,

--- a/test/loanToDepositRatioLimits.js
+++ b/test/loanToDepositRatioLimits.js
@@ -68,7 +68,6 @@ contract("Loan to Deposit ratio tests", accounts => {
 
         const [interestEarnedBalance] = await Promise.all([
             augmintToken.balanceOf(InterestEarnedAccount.address),
-            tokenTestHelpers.issueToReserve(10000000),
             // term (in sec), discountRate, loanCoverageRatio, minDisbursedAmount, defaultingFeePt, isActive
             loanManager.addLoanProduct(60, 1000000, 1000000, 500, 5000, true),
             // (perTermInterest,  durationInSecs, minimumLockAmount, isActive)
@@ -84,7 +83,7 @@ contract("Loan to Deposit ratio tests", accounts => {
             loanManager.getProductCount().then(res => res.toNumber() - 1),
             locker.getLockProductCount().then(res => res.toNumber() - 1),
             rates.rates("EUR").then(res => res[0]),
-            tokenTestHelpers.withdrawFromReserve(accounts[0], 10000000),
+            tokenTestHelpers.issueToken(accounts[0], accounts[0], 10000000),
             tokenTestHelpers.interestEarnedAccount.withdraw(
                 augmintToken.address,
                 accounts[0],

--- a/test/loans.js
+++ b/test/loans.js
@@ -22,7 +22,6 @@ contract("Loans tests", accounts => {
         monetarySupervisor = tokenTestHelpers.monetarySupervisor;
         augmintToken = tokenTestHelpers.augmintToken;
         loanManager = loanTestHelpers.loanManager;
-        await tokenTestHelpers.issueToReserve(1000000000);
 
         const [prodCount] = await Promise.all([
             loanManager.getProductCount().then(res => res.toNumber()),
@@ -45,8 +44,7 @@ contract("Loans tests", accounts => {
 
         const [newProducts] = await Promise.all([
             loanTestHelpers.getProductsInfo(prodCount, CHUNK_SIZE),
-
-            tokenTestHelpers.withdrawFromReserve(accounts[0], 1000000000)
+            tokenTestHelpers.issueToken(accounts[0], accounts[0], 1000000000)
         ]);
         [
             products.notDue,

--- a/test/locker.js
+++ b/test/locker.js
@@ -28,15 +28,13 @@ contract("Lock", accounts => {
         lockerInstance = Locker.at(Locker.address);
 
         await Promise.all([
-            monetarySupervisor.issueToReserve(50000),
             monetarySupervisor.setLtdParams(
                 ltdParams.lockDifferenceLimit,
                 ltdParams.loanDifferenceLimit,
                 ltdParams.allowedDifferenceAmount
             ),
-
-            tokenTestHelpers.withdrawFromReserve(tokenHolder, 40000),
-            tokenTestHelpers.withdrawFromReserve(interestEarnedAddress, 10000)
+            tokenTestHelpers.issueToken(accounts[0], tokenHolder, 40000),
+            tokenTestHelpers.issueToken(accounts[0], interestEarnedAddress, 10000)
         ]);
     });
 

--- a/test/tokenConversion.js
+++ b/test/tokenConversion.js
@@ -13,10 +13,7 @@ contract("token conversion tests", accounts => {
         augmintToken = tokenTestHelpers.augmintToken;
         monetarySupervisor = tokenTestHelpers.monetarySupervisor;
 
-        [newToken] = await Promise.all([
-            AugmintToken.new(accounts[0], tokenTestHelpers.feeAccount.address),
-            tokenTestHelpers.issueToReserve(10000000)
-        ]);
+        newToken = await AugmintToken.new(accounts[0], tokenTestHelpers.feeAccount.address);
 
         newMS = await MonetarySupervisor.new(
             accounts[0],
@@ -75,7 +72,7 @@ contract("token conversion tests", accounts => {
         const account = accounts[0];
 
         await Promise.all([
-            tokenTestHelpers.withdrawFromReserve(account, amount),
+            tokenTestHelpers.issueToken(accounts[0], account, amount),
             newMS.setAcceptedLegacyAugmintToken(augmintToken.address, true)
         ]);
 
@@ -118,7 +115,7 @@ contract("token conversion tests", accounts => {
 
         await Promise.all([
             newMS.setAcceptedLegacyAugmintToken(augmintToken.address, false),
-            tokenTestHelpers.withdrawFromReserve(account, amount)
+            tokenTestHelpers.issueToken(accounts[0], account, amount)
         ]);
 
         await testHelpers.expectThrow(augmintToken.transferAndNotify(newMS.address, amount, 0, { from: account }));

--- a/test/tokenTransfer.js
+++ b/test/tokenTransfer.js
@@ -7,10 +7,9 @@ let minFee, maxFee, feePt, minFeeAmount, maxFeeAmount;
 contract("Transfer Augmint tokens tests", accounts => {
     before(async function() {
         augmintToken = tokenTestHelpers.augmintToken;
-        await tokenTestHelpers.issueToReserve(1000000000);
         await Promise.all([
-            tokenTestHelpers.withdrawFromReserve(accounts[0], 500000000),
-            tokenTestHelpers.withdrawFromReserve(accounts[1], 500000000)
+            tokenTestHelpers.issueToken(accounts[0], accounts[0], 500000000),
+            tokenTestHelpers.issueToken(accounts[0], accounts[1], 500000000)
         ]);
         [feePt, minFee, maxFee] = await tokenTestHelpers.feeAccount.transferFee();
         minFeeAmount = minFee.div(feePt).mul(1000000);

--- a/test/tokenTransferFrom.js
+++ b/test/tokenTransferFrom.js
@@ -8,11 +8,10 @@ contract("TransferFrom AugmintToken tests", accounts => {
     before(async function() {
         augmintToken = tokenTestHelpers.augmintToken;
 
-        await tokenTestHelpers.issueToReserve(1000000000);
         [[, , maxFee], ,] = await Promise.all([
             tokenTestHelpers.feeAccount.transferFee(),
-            tokenTestHelpers.withdrawFromReserve(accounts[0], 500000000),
-            tokenTestHelpers.withdrawFromReserve(accounts[1], 500000000)
+            tokenTestHelpers.issueToken(accounts[0], accounts[0], 500000000),
+            tokenTestHelpers.issueToken(accounts[0], accounts[1], 500000000)
         ]);
     });
 


### PR DESCRIPTION
- AugmintReserves is no longer a SystemAccount, only Restricted
- migrate() method replaces withdraw(): only migrates ETH (to new reserve)
- tests no longer use reserve.withdraw to create test tokens