### PR TITLE
Separate issued and burned amounts in MonetarySupervisor

### DIFF
--- a/contracts/MonetarySupervisor.sol
+++ b/contracts/MonetarySupervisor.sol
@@ -25,7 +25,8 @@ contract MonetarySupervisor is Restricted, TokenReceiver { // solhint-disable-li
     InterestEarnedAccount public interestEarnedAccount;
     AugmintReserves public augmintReserves;
 
-    uint public issuedByStabilityBoard; // token issued  by Stability Board
+    uint public issuedByStabilityBoard; // token issued by Stability Board
+    uint public burnedByStabilityBoard; // token burned by Stability Board
 
     uint public totalLoanAmount; // total amount of all loans without interest, in token
     uint public totalLockedAmount; // total amount of all locks without premium, in token
@@ -80,7 +81,7 @@ contract MonetarySupervisor is Restricted, TokenReceiver { // solhint-disable-li
     }
 
     function burnFromReserve(uint amount) external restrict("StabilityBoard") {
-        issuedByStabilityBoard = issuedByStabilityBoard.sub(amount);
+        burnedByStabilityBoard = burnedByStabilityBoard.add(amount);
         augmintReserves.burn(augmintToken, amount);
     }
 

--- a/test/monetarySupervisor.js
+++ b/test/monetarySupervisor.js
@@ -14,10 +14,11 @@ contract("MonetarySupervisor tests", accounts => {
 
     it("should be possible to issue new tokens to reserve", async function() {
         const amount = 100000;
-        const [totalSupplyBefore, reserveBalBefore, issuedByStabilityBoardBefore] = await Promise.all([
+        const [totalSupplyBefore, reserveBalBefore, issuedByStabilityBoardBefore, burnedByStabilityBoardBefore] = await Promise.all([
             augmintToken.totalSupply(),
             augmintToken.balanceOf(augmintReserves.address),
-            monetarySupervisor.issuedByStabilityBoard()
+            monetarySupervisor.issuedByStabilityBoard(),
+            monetarySupervisor.burnedByStabilityBoard()
         ]);
 
         const tx = await monetarySupervisor.issueToReserve(amount);
@@ -29,10 +30,11 @@ contract("MonetarySupervisor tests", accounts => {
             amount: amount
         });
 
-        const [totalSupply, issuedByStabilityBoard, reserveBal] = await Promise.all([
+        const [totalSupply, reserveBal, issuedByStabilityBoard, burnedByStabilityBoard] = await Promise.all([
             augmintToken.totalSupply(),
             augmintToken.balanceOf(augmintReserves.address),
-            monetarySupervisor.issuedByStabilityBoard()
+            monetarySupervisor.issuedByStabilityBoard(),
+            monetarySupervisor.burnedByStabilityBoard()
         ]);
 
         assert.equal(
@@ -44,6 +46,11 @@ contract("MonetarySupervisor tests", accounts => {
             issuedByStabilityBoard.toString(),
             issuedByStabilityBoardBefore.add(amount).toString(),
             "issuedByStabilityBoard should be increased with issued amount"
+        );
+        assert.equal(
+            burnedByStabilityBoard.toString(),
+            burnedByStabilityBoardBefore.toString(),
+            "burnedByStabilityBoard should not change"
         );
         assert.equal(
             reserveBal.toString(),

--- a/test/monetarySupervisor.js
+++ b/test/monetarySupervisor.js
@@ -59,10 +59,11 @@ contract("MonetarySupervisor tests", accounts => {
     it("should be possible to burn tokens from reserve", async function() {
         const amount = 9000000;
         await monetarySupervisor.issueToReserve(amount);
-        const [totalSupplyBefore, reserveBalBefore, issuedByStabilityBoardBefore] = await Promise.all([
+        const [totalSupplyBefore, reserveBalBefore, issuedByStabilityBoardBefore, burnedByStabilityBoardBefore] = await Promise.all([
             augmintToken.totalSupply(),
             augmintToken.balanceOf(augmintReserves.address),
-            monetarySupervisor.issuedByStabilityBoard()
+            monetarySupervisor.issuedByStabilityBoard(),
+            monetarySupervisor.burnedByStabilityBoard()
         ]);
 
         const tx = await monetarySupervisor.burnFromReserve(amount, { from: accounts[0] });
@@ -74,10 +75,11 @@ contract("MonetarySupervisor tests", accounts => {
             amount: amount
         });
 
-        const [totalSupply, issuedByStabilityBoard, reserveBal] = await Promise.all([
+        const [totalSupply, reserveBal, issuedByStabilityBoard, burnedByStabilityBoard] = await Promise.all([
             augmintToken.totalSupply(),
             augmintToken.balanceOf(augmintReserves.address),
-            monetarySupervisor.issuedByStabilityBoard()
+            monetarySupervisor.issuedByStabilityBoard(),
+            monetarySupervisor.burnedByStabilityBoard()
         ]);
         assert.equal(
             totalSupply.toString(),
@@ -86,8 +88,13 @@ contract("MonetarySupervisor tests", accounts => {
         );
         assert.equal(
             issuedByStabilityBoard.toString(),
-            issuedByStabilityBoardBefore.sub(amount).toString(),
-            "issuedByStabilityBoard should be decreased with burnt amount"
+            issuedByStabilityBoardBefore.toString(),
+            "issuedByStabilityBoard should not change"
+        );
+        assert.equal(
+            burnedByStabilityBoard.toString(),
+            burnedByStabilityBoardBefore.add(amount).toString(),
+            "burnedByStabilityBoard should be increased with burnt amount"
         );
         assert.equal(
             reserveBal.toString(),


### PR DESCRIPTION
Separate issued and burned amount counters in MonetarySupervisor, to allow burned amount to be larger than issued amount.
(These counters only represent issued and burned token amounts by the StabilityBoard, for the AugmintReserves, via the MonetarySupervisor)