### PR TITLE
adjust loan discountrates

### DIFF
--- a/contracts/SB_scripts/localTest/localTest_initialSetup.sol
+++ b/contracts/SB_scripts/localTest/localTest_initialSetup.sol
@@ -105,13 +105,13 @@ contract localTest_initialSetup {
 
         // add test loan Products
         // term (in sec), discountRate, loanCoverageRatio, minDisbursedAmount (w/ 4 decimals), defaultingFeePt, isActive
-        _loanManager.addLoanProduct(365 days, 854700, 550000, 1000, 50000, true); //  17% p.a.
-        _loanManager.addLoanProduct(180 days, 924752, 550000, 1000, 50000, true); // 16.5% p.a.
+        _loanManager.addLoanProduct(365 days, 854701, 550000, 1000, 50000, true); //  17% p.a.
+        _loanManager.addLoanProduct(180 days, 924753, 550000, 1000, 50000, true); // 16.5% p.a.
 
-        _loanManager.addLoanProduct(90 days, 962045, 600000, 1000, 50000, true); // 16%. p.a.
-        _loanManager.addLoanProduct(60 days, 975153, 600000, 1000, 50000, true); //  15.5% p.a.
-        _loanManager.addLoanProduct(30 days, 987821, 600000, 1000, 50000, true); //  15% p.a.
-        _loanManager.addLoanProduct(14 days, 994279, 600000, 1000, 50000, true); // 15% p.a.
+        _loanManager.addLoanProduct(90 days, 962046, 600000, 1000, 50000, true); // 16%. p.a.
+        _loanManager.addLoanProduct(60 days, 975154, 600000, 1000, 50000, true); //  15.5% p.a.
+        _loanManager.addLoanProduct(30 days, 987822, 600000, 1000, 50000, true); //  15% p.a.
+        _loanManager.addLoanProduct(14 days, 994280, 600000, 1000, 50000, true); // 15% p.a.
         _loanManager.addLoanProduct(7 days, 997132, 600000, 1000, 50000, true); // 15% p.a.
 
         _loanManager.addLoanProduct(1 hours, 999998, 980000, 2000, 50000, true); // due in 1hr for testing repayments ? p.a.

--- a/test/loanManager.js
+++ b/test/loanManager.js
@@ -37,6 +37,27 @@ contract("loanManager  tests", accounts => {
         loanProduct.id = res.productId;
     });
 
+    it("Verifies default test loanproducts", async function() {
+        // correlates with loan products set up in localTest_initialSetup.sol
+
+        // IRPA: Interest Rate Per Annum : the percentage value on the UI
+        // LPDR: Loan Product Discount Rate : uint32 discountRate constructor parameter
+
+        // IRPA = (1_000_000 / LPDR - 1) * (365 / termInDays)
+        // LPDR = 1_000_000 / (IRPA * termInDays / 365 + 1)
+
+        const toLdpr = (irpa, termInDays) => Math.ceil(1000000 / (irpa * termInDays / 365 + 1))
+
+        const p = await loanTestHelpers.getProductsInfo(0, CHUNK_SIZE);
+        assert.equal(p[0].discountRate.toNumber(), toLdpr(0.17, 365))
+        assert.equal(p[1].discountRate.toNumber(), toLdpr(0.165, 180))
+        assert.equal(p[2].discountRate.toNumber(), toLdpr(0.16, 90))
+        assert.equal(p[3].discountRate.toNumber(), toLdpr(0.155, 60))
+        assert.equal(p[4].discountRate.toNumber(), toLdpr(0.15, 30))
+        assert.equal(p[5].discountRate.toNumber(), toLdpr(0.15, 14))
+        assert.equal(p[6].discountRate.toNumber(), toLdpr(0.15, 7))
+    });
+
     it("Should add new product allow listing from offset 0", async function() {
         const prod = {
             // assuming prod attributes are same order as array returned

--- a/test/loanManager.js
+++ b/test/loanManager.js
@@ -37,7 +37,7 @@ contract("loanManager  tests", accounts => {
         loanProduct.id = res.productId;
     });
 
-    it("Verifies default test loanproducts", async function() {
+    it("Verifies default test loanproduct discount rates", async function() {
         // correlates with loan products set up in localTest_initialSetup.sol
 
         // IRPA: Interest Rate Per Annum : the percentage value on the UI
@@ -46,16 +46,16 @@ contract("loanManager  tests", accounts => {
         // IRPA = (1_000_000 / LPDR - 1) * (365 / termInDays)
         // LPDR = 1_000_000 / (IRPA * termInDays / 365 + 1)
 
-        const toLdpr = (irpa, termInDays) => Math.ceil(1000000 / (irpa * termInDays / 365 + 1))
+        const toLpdr = (irpa, termInDays) => Math.ceil(1000000 / (irpa * termInDays / 365 + 1))
 
         const p = await loanTestHelpers.getProductsInfo(0, CHUNK_SIZE);
-        assert.equal(p[0].discountRate.toNumber(), toLdpr(0.17, 365))
-        assert.equal(p[1].discountRate.toNumber(), toLdpr(0.165, 180))
-        assert.equal(p[2].discountRate.toNumber(), toLdpr(0.16, 90))
-        assert.equal(p[3].discountRate.toNumber(), toLdpr(0.155, 60))
-        assert.equal(p[4].discountRate.toNumber(), toLdpr(0.15, 30))
-        assert.equal(p[5].discountRate.toNumber(), toLdpr(0.15, 14))
-        assert.equal(p[6].discountRate.toNumber(), toLdpr(0.15, 7))
+        assert.equal(p[0].discountRate.toNumber(), toLpdr(0.17, 365))
+        assert.equal(p[1].discountRate.toNumber(), toLpdr(0.165, 180))
+        assert.equal(p[2].discountRate.toNumber(), toLpdr(0.16, 90))
+        assert.equal(p[3].discountRate.toNumber(), toLpdr(0.155, 60))
+        assert.equal(p[4].discountRate.toNumber(), toLpdr(0.15, 30))
+        assert.equal(p[5].discountRate.toNumber(), toLpdr(0.15, 14))
+        assert.equal(p[6].discountRate.toNumber(), toLpdr(0.15, 7))
     });
 
     it("Should add new product allow listing from offset 0", async function() {


### PR DESCRIPTION
discountrate was historically set using an old interest rate calculator where it wasn't rounded properly.  

This PR sets the discount rates with rounding them up so they reflect actual intention of interest rate p.a.  on local test deployment (NB: IT must be done on mainnet too, same issue there. No issue with rinkeby rates, those already used the new calculator when were set)

To reproduce the issue: get a 1 year loan on local test ganache. 17% for 100AEUR results 117.01 repayment( see screenshot).
 NB: there is an[ other **independent** issue](https://github.com/Augmint/augmint-web/issues/629) on the FE which results the actual loan disbursed to be slightly off too.


[Interest p.a. => discount rate calculator](https://docs.google.com/spreadsheets/d/1MeWYPYZRIm1n9lzpvbq8kLfQg1hhvk5oJY6NrR401S0/edit#gid=1969879364)

![image](https://user-images.githubusercontent.com/7456451/57579189-8bbc5900-7490-11e9-9ae5-7006caee484a.png)
