### PR TITLE
SB script dry execution

### DIFF
--- a/contracts/generic/MultiSig.sol
+++ b/contracts/generic/MultiSig.sol
@@ -91,12 +91,10 @@ contract MultiSig {
     function dryExecute(address scriptAddress) public {
         bool result = _execute(scriptAddress);
 
-        // solium-disable-next-line security/no-inline-assembly
-        assembly {
-            let ptr := mload(0x40) // starts from the "free memory pointer"
-
-            if eq(result, 0) {
-                // if delegatecall failed then revert with the revert returndata
+        if(!result) { // if delegatecall failed then revert with the revert returndata
+            // solium-disable-next-line security/no-inline-assembly
+            assembly {
+                let ptr := mload(0x40) // starts from the "free memory pointer"
                 returndatacopy(ptr, 0, returndatasize) // retreive delegatecall revert reason message
                 revert(ptr, returndatasize)  // revert with the reason message from delegeatecall
             }

--- a/contracts/generic/MultiSig.sol
+++ b/contracts/generic/MultiSig.sol
@@ -86,18 +86,19 @@ contract MultiSig {
 
         result = _execute(scriptAddress);
     }
-
-    function dryExecute(address scriptAddress) public returns (bool result) {
-        result = _execute(scriptAddress);
+    /* Function to test scripts without signatures - always reverts.
+        It's even possible to test scripts without deployment if script deployed and dry run on a ganache */
+    function dryExecute(address scriptAddress) public {
+        bool result = _execute(scriptAddress);
 
         // solium-disable-next-line security/no-inline-assembly
         assembly {
-            let ptr := mload(0x40)
-            returndatacopy(ptr, 0, returndatasize)
+            let ptr := mload(0x40) // starts from the "free memory pointer"
 
             if eq(result, 0) {
                 // if delegatecall failed then revert with the revert returndata
-                revert(ptr, returndatasize)
+                returndatacopy(ptr, 0, returndatasize) // retreive delegatecall revert reason message
+                revert(ptr, returndatasize)  // revert with the reason message from delegeatecall
             }
         }
 

--- a/contracts/generic/MultiSig.sol
+++ b/contracts/generic/MultiSig.sol
@@ -110,7 +110,7 @@ contract MultiSig {
     /* requires quorum so it's callable only via a script executed by this contract */
     function addSigners(address[] signers) public {
         require(msg.sender == address(this), "only callable via MultiSig");
-        for (uint i= 0; i < signers.length; i++) {
+        for (uint i = 0; i < signers.length; i++) {
             if (!isSigner[signers[i]]) {
                 require(signers[i] != address(0), "new signer must not be 0x0");
                 activeSignersCount++;
@@ -124,7 +124,7 @@ contract MultiSig {
     /* requires quorum so it's callable only via a script executed by this contract */
     function removeSigners(address[] signers) public {
         require(msg.sender == address(this), "only callable via MultiSig");
-        for (uint i= 0; i < signers.length; i++) {
+        for (uint i = 0; i < signers.length; i++) {
             if (isSigner[signers[i]]) {
                 require(activeSignersCount > 1, "must not remove last signer");
                 activeSignersCount--;
@@ -137,7 +137,7 @@ contract MultiSig {
     /* implement it in derived contract */
     function checkQuorum(uint signersCount) internal view returns(bool isQuorum);
 
-    function getAllSignersCount() view external returns (uint allSignersCount) {
+    function getAllSignersCount() external view returns (uint allSignersCount) {
         return allSigners.length;
     }
 
@@ -153,7 +153,7 @@ contract MultiSig {
         return response;
     }
 
-    function getScriptsCount() view external returns (uint scriptsCount) {
+    function getScriptsCount() external view returns (uint scriptsCount) {
         return scriptAddresses.length;
     }
 

--- a/contracts/scriptTests/SB_revertingNoReasonScript.sol
+++ b/contracts/scriptTests/SB_revertingNoReasonScript.sol
@@ -1,0 +1,15 @@
+/* test script to simulate revert() in script execute() to multiSig
+*/
+
+pragma solidity 0.4.24;
+
+
+contract SB_revertingNoReasonScript {
+
+    function execute(SB_revertingNoReasonScript self) pure external {
+        require(address(self) != 0, "just to silence unused var compiler warning");
+        // solium-disable-next-line error-reason
+        revert();
+    }
+
+}

--- a/test/stabilityBoardProxy.js
+++ b/test/stabilityBoardProxy.js
@@ -20,10 +20,12 @@ async function addSigners(newSigners) {
         stabilityBoardProxy.getSigners(0, CHUNK_SIZE)
     ]);
 
-    const signTxs = currentSigners.filter(signerTuple => !signerTuple[1].eq(0)).map(tuple => {
-        const signerAddress = "0x" + tuple[1].toString(16).padStart(40, "0");
-        return stabilityBoardProxy.sign(addSignerScript.address, { from: signerAddress });
-    });
+    const signTxs = currentSigners
+        .filter(signerTuple => !signerTuple[1].eq(0))
+        .map(tuple => {
+            const signerAddress = "0x" + tuple[1].toString(16).padStart(40, "0");
+            return stabilityBoardProxy.sign(addSignerScript.address, { from: signerAddress });
+        });
 
     const signCount = Math.floor(signTxs.length / 2) + 1;
     await Promise.all(signTxs.slice(0, signCount));
@@ -295,9 +297,7 @@ contract("StabilityBoardProxy", accounts => {
         // create , sign & execute a script to cancel our removeSignerScript
         const cancelScript = await SB_cancelScript.new(removeSignerScript.address);
         await Promise.all(
-            [...newSigners, accounts[0]].map(signer =>
-                stabilityBoardProxy.sign(cancelScript.address, { from: signer })
-            )
+            [...newSigners, accounts[0]].map(signer => stabilityBoardProxy.sign(cancelScript.address, { from: signer }))
         );
 
         const cancelTx = await stabilityBoardProxy.execute(cancelScript.address, { from: accounts[0] });
@@ -428,14 +428,16 @@ contract("StabilityBoardProxy", accounts => {
             stabilityBoardProxy.getScriptsCount().then(res => res.toNumber()),
             stabilityBoardProxy.getScripts(scriptCountBefore, CHUNK_SIZE)
         ]);
-        const scripts = scriptsArray.filter(item => !item[1].eq(0)).map(item => {
-            return {
-                index: item[0].toNumber(),
-                address: "0x" + item[1].toString(16).padStart(40, "0"),
-                state: item[2].toNumber(),
-                signCount: item[3].toNumber()
-            };
-        });
+        const scripts = scriptsArray
+            .filter(item => !item[1].eq(0))
+            .map(item => {
+                return {
+                    index: item[0].toNumber(),
+                    address: "0x" + item[1].toString(16).padStart(40, "0"),
+                    state: item[2].toNumber(),
+                    signCount: item[3].toNumber()
+                };
+            });
 
         assert.equal(scripts.length, 3);
         assert.equal(scriptsCountAfter, scriptCountBefore + 3);
@@ -470,5 +472,43 @@ contract("StabilityBoardProxy", accounts => {
 
     it("should not call removeSigners directly", async function() {
         testHelpers.expectThrow(stabilityBoardProxy.removeSigners([accounts[0]]));
+    });
+
+    it("should dryExecute a script (success)", async function() {
+        const addSignerScript = await SB_addAndRemoveSigners.new();
+
+        try {
+            await stabilityBoardProxy.dryExecute(addSignerScript.address);
+            assert.fail("Should be rejected");
+        } catch (error) {
+            assert.include(error.message, "VM Exception while processing transaction: revert dryExecute success");
+        }
+
+        let [allSignersCountAfter, script] = await Promise.all([
+            stabilityBoardProxy.getAllSignersCount(),
+            stabilityBoardProxyWeb3Contract.methods.scripts(addSignerScript.address).call(),
+            testHelpers.assertNoEvents(stabilityBoardProxy, "ScriptExecuted")
+        ]);
+
+        assert.equal(script.state, scriptState.New);
+        assert.equal(allSignersCountAfter.toNumber(), 1);
+    });
+
+    it("should dryExecute a script (fail)", async function() {
+        const revertingScript = await SB_revertingScript.new();
+
+        try {
+            await stabilityBoardProxy.dryExecute(revertingScript.address);
+            assert.fail("Should be rejected");
+        } catch (error) {
+            assert.include(error.message, "VM Exception while processing transaction: revert dryExecute fail");
+        }
+
+        let [script] = await Promise.all([
+            stabilityBoardProxyWeb3Contract.methods.scripts(revertingScript.address).call(),
+            testHelpers.assertNoEvents(stabilityBoardProxy, "ScriptExecuted")
+        ]);
+
+        assert.equal(script.state, scriptState.New);
     });
 });

--- a/test/stabilityBoardProxy.js
+++ b/test/stabilityBoardProxy.js
@@ -501,7 +501,10 @@ contract("StabilityBoardProxy", accounts => {
             await stabilityBoardProxy.dryExecute(revertingScript.address);
             assert.fail("Should be rejected");
         } catch (error) {
-            assert.include(error.message, "VM Exception while processing transaction: revert dryExecute fail");
+            assert.include(
+                error.message,
+                "VM Exception while processing transaction: revert intentional revert for test"
+            );
         }
 
         let [script] = await Promise.all([


### PR DESCRIPTION
`dryExecute` method without signature check - reverts in all cases with result in reason string.

It still needs to be tested on a local ganache forked from mainnet.

NB: in Solc 5+ it could be done without inline assembly:
```solidity
bytes memory returndata;
(result, returndata) = scriptAddress.delegatecall(sig);
require(result, string(returndata));
```