### PR TITLE
mega truffle upgrade (no contract changes)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM trufflesuite/ganache-cli:v6.4.2
+FROM trufflesuite/ganache-cli:v6.10.2
 COPY ["localchaindb", "dockerLocalchaindb"]

--- a/migrations/1000_initialSetup.js
+++ b/migrations/1000_initialSetup.js
@@ -12,7 +12,7 @@ const SafeMathTester = artifacts.require("./test/SafeMathTester.sol");
 
 const localTest_initialSetup = artifacts.require("./SB_scripts/localTest/localTest_initialSetup.sol");
 
-module.exports = function(deployer) {
+module.exports = function (deployer) {
     deployer
         .deploy(
             localTest_initialSetup,
@@ -27,31 +27,54 @@ module.exports = function(deployer) {
             Exchange.address,
             SafeMathTester.address
         )
-        .then(async initialSetupScript => {
+        .then(async (initialSetupScript) => {
             // StabilityBoard permissions
-            const rates = Rates.at(Rates.address);
-            const feeAccount = FeeAccount.at(FeeAccount.address);
-            const interestEarnedAccount = InterestEarnedAccount.at(InterestEarnedAccount.address);
-            const tokenAEur = TokenAEur.at(TokenAEur.address);
-            const augmintReserves = AugmintReserves.at(AugmintReserves.address);
-            const monetarySupervisor = MonetarySupervisor.at(MonetarySupervisor.address);
-            const loanManager = LoanManager.at(LoanManager.address);
-            const locker = Locker.at(Locker.address);
-            const exchange = Exchange.at(Exchange.address);
+            const [
+                rates,
+                feeAccount,
+                interestEarnedAccount,
+                tokenAEur,
+                augmintReserves,
+                monetarySupervisor,
+                loanManager,
+                locker,
+                exchange,
+                stabilityBoardProxy,
+            ] = await Promise.all([
+                Rates.at(Rates.address),
+                FeeAccount.at(FeeAccount.address),
+                InterestEarnedAccount.at(InterestEarnedAccount.address),
+                TokenAEur.at(TokenAEur.address),
+                AugmintReserves.at(AugmintReserves.address),
+                MonetarySupervisor.at(MonetarySupervisor.address),
+                LoanManager.at(LoanManager.address),
+                Locker.at(Locker.address),
+                Exchange.at(Exchange.address),
+                StabilityBoardProxy.at(StabilityBoardProxy.address),
+            ]);
+
             await Promise.all([
-                rates.grantPermission(StabilityBoardProxy.address, "PermissionGranter"),
-                feeAccount.grantPermission(StabilityBoardProxy.address, "PermissionGranter"),
-                interestEarnedAccount.grantPermission(StabilityBoardProxy.address, "PermissionGranter"),
-                tokenAEur.grantPermission(StabilityBoardProxy.address, "PermissionGranter"),
-                augmintReserves.grantPermission(StabilityBoardProxy.address, "PermissionGranter"),
-                monetarySupervisor.grantPermission(StabilityBoardProxy.address, "PermissionGranter"),
-                loanManager.grantPermission(StabilityBoardProxy.address, "PermissionGranter"),
-                locker.grantPermission(StabilityBoardProxy.address, "PermissionGranter"),
-                exchange.grantPermission(StabilityBoardProxy.address, "PermissionGranter")
+                rates.grantPermission(StabilityBoardProxy.address, web3.utils.asciiToHex("PermissionGranter")),
+                feeAccount.grantPermission(StabilityBoardProxy.address, web3.utils.asciiToHex("PermissionGranter")),
+                interestEarnedAccount.grantPermission(
+                    StabilityBoardProxy.address,
+                    web3.utils.asciiToHex("PermissionGranter")
+                ),
+                tokenAEur.grantPermission(StabilityBoardProxy.address, web3.utils.asciiToHex("PermissionGranter")),
+                augmintReserves.grantPermission(
+                    StabilityBoardProxy.address,
+                    web3.utils.asciiToHex("PermissionGranter")
+                ),
+                monetarySupervisor.grantPermission(
+                    StabilityBoardProxy.address,
+                    web3.utils.asciiToHex("PermissionGranter")
+                ),
+                loanManager.grantPermission(StabilityBoardProxy.address, web3.utils.asciiToHex("PermissionGranter")),
+                locker.grantPermission(StabilityBoardProxy.address, web3.utils.asciiToHex("PermissionGranter")),
+                exchange.grantPermission(StabilityBoardProxy.address, web3.utils.asciiToHex("PermissionGranter")),
             ]);
 
             // run initial setup script
-            const stabilityBoardProxy = StabilityBoardProxy.at(StabilityBoardProxy.address);
             await stabilityBoardProxy.sign(initialSetupScript.address);
             const tx = await stabilityBoardProxy.execute(initialSetupScript.address);
 

--- a/migrations/1001_topup_interestEarnedAccount.js
+++ b/migrations/1001_topup_interestEarnedAccount.js
@@ -3,12 +3,14 @@ const TokenAEur = artifacts.require("./TokenAEur.sol");
 const LoanManager = artifacts.require("./LoanManager.sol");
 const InterestEarnedAccount = artifacts.require("./InterestEarnedAccount.sol");
 
-module.exports = function(deployer) {
+module.exports = function (deployer) {
     deployer.then(async () => {
-        const tokenAEur = TokenAEur.at(TokenAEur.address);
-        const loanManager = LoanManager.at(LoanManager.address);
+        const [tokenAEur, loanManager] = await Promise.all([
+            TokenAEur.at(TokenAEur.address),
+            LoanManager.at(LoanManager.address),
+        ]);
 
-        await loanManager.newEthBackedLoan(0, 0, { value: web3.toWei(0.10845) }); // = 50 A-EUR
+        await loanManager.newEthBackedLoan(0, 0, { value: web3.utils.toWei("0.10845") }); // = 50 A-EUR
 
         await tokenAEur.transferWithNarrative(
             InterestEarnedAccount.address,

--- a/migrations/1002_authorise_StabilityBoard.js
+++ b/migrations/1002_authorise_StabilityBoard.js
@@ -11,28 +11,39 @@ const LoanManager = artifacts.require("./LoanManager.sol");
 const Locker = artifacts.require("./Locker.sol");
 const Exchange = artifacts.require("./Exchange.sol");
 
-module.exports = function(deployer, network, accounts) {
+module.exports = function (deployer, network, accounts) {
     deployer.then(async () => {
         const stabilityBoardAccounts = [accounts[0]];
 
-        const feeAccount = FeeAccount.at(FeeAccount.address);
-        const augmintReserves = AugmintReserves.at(AugmintReserves.address);
-        const tokenAEur = TokenAEur.at(TokenAEur.address);
-        const interestEarnedAccount = InterestEarnedAccount.at(InterestEarnedAccount.address);
-        const monetarySupervisor = MonetarySupervisor.at(MonetarySupervisor.address);
-        const loanManager = LoanManager.at(LoanManager.address);
-        const locker = Locker.at(Locker.address);
-        const exchange = Exchange.at(Exchange.address);
+        const [
+            feeAccount,
+            augmintReserves,
+            tokenAEur,
+            interestEarnedAccount,
+            monetarySupervisor,
+            loanManager,
+            locker,
+            exchange,
+        ] = await Promise.all([
+            FeeAccount.at(FeeAccount.address),
+            AugmintReserves.at(AugmintReserves.address),
+            TokenAEur.at(TokenAEur.address),
+            InterestEarnedAccount.at(InterestEarnedAccount.address),
+            MonetarySupervisor.at(MonetarySupervisor.address),
+            LoanManager.at(LoanManager.address),
+            Locker.at(Locker.address),
+            Exchange.at(Exchange.address),
+        ]);
 
-        const grantTxs = stabilityBoardAccounts.map(acc => [
-            feeAccount.grantPermission(acc, "StabilityBoard"),
-            augmintReserves.grantPermission(acc, "StabilityBoard"),
-            tokenAEur.grantPermission(acc, "StabilityBoard"),
-            interestEarnedAccount.grantPermission(acc, "StabilityBoard"),
-            monetarySupervisor.grantPermission(acc, "StabilityBoard"),
-            locker.grantPermission(acc, "StabilityBoard"),
-            loanManager.grantPermission(acc, "StabilityBoard"),
-            exchange.grantPermission(acc, "StabilityBoard")
+        const grantTxs = stabilityBoardAccounts.map((acc) => [
+            feeAccount.grantPermission(acc, web3.utils.asciiToHex("StabilityBoard")),
+            augmintReserves.grantPermission(acc, web3.utils.asciiToHex("StabilityBoard")),
+            tokenAEur.grantPermission(acc, web3.utils.asciiToHex("StabilityBoard")),
+            interestEarnedAccount.grantPermission(acc, web3.utils.asciiToHex("StabilityBoard")),
+            monetarySupervisor.grantPermission(acc, web3.utils.asciiToHex("StabilityBoard")),
+            locker.grantPermission(acc, web3.utils.asciiToHex("StabilityBoard")),
+            loanManager.grantPermission(acc, web3.utils.asciiToHex("StabilityBoard")),
+            exchange.grantPermission(acc, web3.utils.asciiToHex("StabilityBoard")),
         ]);
 
         await Promise.all(grantTxs);

--- a/migrations/1003_add_legacyContracts.js
+++ b/migrations/1003_add_legacyContracts.js
@@ -8,10 +8,12 @@ const Locker = artifacts.require("./Locker.sol");
 const LoanManager_1_0_12 = artifacts.require("./legacy/1.0.12/LoanManager_1_0_12.sol");
 const Exchange = artifacts.require("./Exchange.sol");
 
-module.exports = async function(deployer, network, accounts) {
+module.exports = async function (deployer, network, accounts) {
     deployer.then(async () => {
-        const monetarySupervisor = MonetarySupervisor.at(MonetarySupervisor.address);
-        const feeAccount = FeeAccount.at(FeeAccount.address);
+        const [monetarySupervisor, feeAccount] = await Promise.all([
+            MonetarySupervisor.at(MonetarySupervisor.address),
+            FeeAccount.at(FeeAccount.address),
+        ]);
 
         const oldToken = await TokenAEur.new(accounts[0], FeeAccount.address);
 
@@ -25,32 +27,32 @@ module.exports = async function(deployer, network, accounts) {
         const oldExchange = await Exchange.new(accounts[0], oldToken.address, Rates.address);
 
         await Promise.all([
-            oldLoanManager.grantPermission(accounts[0], "StabilityBoard"),
-            oldLocker.grantPermission(accounts[0], "StabilityBoard"),
-            oldExchange.grantPermission(accounts[0], "StabilityBoard")
+            oldLoanManager.grantPermission(accounts[0], web3.utils.asciiToHex("StabilityBoard")),
+            oldLocker.grantPermission(accounts[0], web3.utils.asciiToHex("StabilityBoard")),
+            oldExchange.grantPermission(accounts[0], web3.utils.asciiToHex("StabilityBoard")),
         ]);
 
         await Promise.all([
-            oldToken.grantPermission(MonetarySupervisor.address, "MonetarySupervisor"),
+            oldToken.grantPermission(MonetarySupervisor.address, web3.utils.asciiToHex("MonetarySupervisor")),
 
             monetarySupervisor.setAcceptedLegacyAugmintToken(oldToken.address, true),
 
-            oldToken.grantPermission(accounts[0], "MonetarySupervisor"), // "hack" for test to issue
+            oldToken.grantPermission(accounts[0], web3.utils.asciiToHex("MonetarySupervisor")), // "hack" for test to issue
 
             /* Locker permissions  & products */
-            monetarySupervisor.grantPermission(oldLocker.address, "Locker"),
-            feeAccount.grantPermission(oldLocker.address, "NoTransferFee"),
+            monetarySupervisor.grantPermission(oldLocker.address, web3.utils.asciiToHex("Locker")),
+            feeAccount.grantPermission(oldLocker.address, web3.utils.asciiToHex("NoTransferFee")),
             oldLocker.addLockProduct(80001, 31536000, 1000, true), // 365 days, 8% p.a.
             oldLocker.addLockProduct(1, 60, 1000, true), // 1 minute for testing, ~69.15% p.a.
 
             /* LoanManager permissions & products */
-            monetarySupervisor.grantPermission(oldLoanManager.address, "LoanManager"),
-            feeAccount.grantPermission(oldLoanManager.address, "NoTransferFee"),
+            monetarySupervisor.grantPermission(oldLoanManager.address, web3.utils.asciiToHex("LoanManager")),
+            feeAccount.grantPermission(oldLoanManager.address, web3.utils.asciiToHex("NoTransferFee")),
             oldLoanManager.addLoanProduct(1, 999999, 990000, 1000, 50000, true), // defaults in 1 secs for testing ? p.a.
             oldLoanManager.addLoanProduct(3600, 999989, 980000, 1000, 50000, true), // due in 1hr for testing repayments ? p.a.
             oldLoanManager.addLoanProduct(31536000, 860000, 550000, 1000, 50000, true), // 365d, 14% p.a.
             /* Exchange permissions */
-            feeAccount.grantPermission(oldExchange.address, "NoTransferFee")
+            feeAccount.grantPermission(oldExchange.address, web3.utils.asciiToHex("NoTransferFee")),
         ]);
 
         await oldToken.issueTo(accounts[0], 20000); // issue some to account 0
@@ -59,12 +61,12 @@ module.exports = async function(deployer, network, accounts) {
             oldToken.transferAndNotify(oldLocker.address, 1500, 0),
             oldToken.transferAndNotify(oldLocker.address, 1600, 1),
 
-            oldLoanManager.newEthBackedLoan(0, { value: web3.toWei(0.1) }),
-            oldLoanManager.newEthBackedLoan(2, { value: web3.toWei(0.2) }),
+            oldLoanManager.newEthBackedLoan(0, { value: web3.utils.toWei("0.1") }),
+            oldLoanManager.newEthBackedLoan(2, { value: web3.utils.toWei("0.2") }),
             oldToken.transferAndNotify(oldExchange.address, 2000, 1010000),
             oldToken.transferAndNotify(oldExchange.address, 1100, 980000),
-            oldExchange.placeBuyTokenOrder(990000, { value: web3.toWei(0.01) }),
-            oldExchange.placeBuyTokenOrder(1020000, { value: web3.toWei(0.011) })
+            oldExchange.placeBuyTokenOrder(990000, { value: web3.utils.toWei("0.01") }),
+            oldExchange.placeBuyTokenOrder(1020000, { value: web3.utils.toWei("0.011") }),
         ]);
 
         console.log(

--- a/migrations/1004_add_test_preTokens.js
+++ b/migrations/1004_add_test_preTokens.js
@@ -3,28 +3,28 @@
 \ */
 const PreToken = artifacts.require("./PreToken.sol");
 
-module.exports = function(deployer, network, accounts) {
+module.exports = function (deployer, network, accounts) {
     deployer.then(async () => {
-        const preToken = PreToken.at(PreToken.address);
-        await preToken.grantPermission(accounts[0], "PreTokenSigner"); // only on local test to allow issuance w/o MultiSig
+        const preToken = await PreToken.at(PreToken.address);
+        await preToken.grantPermission(accounts[0], web3.utils.asciiToHex("PreTokenSigner")); // only on local test to allow issuance w/o MultiSig
         const AC0_AGREEMENT = "0xa100000000000000000000000000000000000000000000000000000000000001";
         const AC1_AGREEMENT = "0xa200000000000000000000000000000000000000000000000000000000000002";
         await Promise.all([
             // addAgreement(owner, agreementHash,  discount, valuationCap)
             preToken.addAgreement(accounts[0], AC0_AGREEMENT, 800000, 30000000),
-            preToken.addAgreement(accounts[1], AC1_AGREEMENT, 850000, 40000000)
+            preToken.addAgreement(accounts[1], AC1_AGREEMENT, 850000, 40000000),
         ]);
 
         await Promise.all([
             preToken.issueTo(AC0_AGREEMENT, 10000),
             preToken.issueTo(AC0_AGREEMENT, 9000),
             preToken.issueTo(AC0_AGREEMENT, 8000),
-            preToken.issueTo(AC1_AGREEMENT, 7000)
+            preToken.issueTo(AC1_AGREEMENT, 7000),
         ]);
 
         await Promise.all([
             preToken.transfer(accounts[2], 7000, { from: accounts[1] }),
-            preToken.burnFrom(AC0_AGREEMENT, 1000)
+            preToken.burnFrom(AC0_AGREEMENT, 1000),
         ]);
     });
 };

--- a/migrations/2000_setRateDefault.js
+++ b/migrations/2000_setRateDefault.js
@@ -2,11 +2,11 @@
 // run it with: "truffle migrate -f 2000 --to 2000" or "setrate:default"
 
 const Rates = artifacts.require("./Rates.sol");
-const newRate = 99800;
+const newRate = "99800";
 
-module.exports = function(deployer) {
+module.exports = function (deployer) {
     deployer.then(async () => {
-        const rates = Rates.at(Rates.address);
-        await rates.setRate("EUR", newRate);
+        const rates = await Rates.at(Rates.address);
+        await rates.setRate(web3.utils.asciiToHex("EUR"), newRate);
     });
 };

--- a/migrations/2001_setRateLow.js
+++ b/migrations/2001_setRateLow.js
@@ -2,11 +2,11 @@
 // run it with: "truffle migrate -f 2001 --to 2001" or "setrate:low"
 
 const Rates = artifacts.require("./Rates.sol");
-const newRate = 42500;
+const newRate = "42500";
 
-module.exports = function(deployer) {
+module.exports = function (deployer) {
     deployer.then(async () => {
-        const rates = Rates.at(Rates.address);
-        await rates.setRate("EUR", newRate);
+        const rates = await Rates.at(Rates.address);
+        await rates.setRate(web3.utils.asciiToHex("EUR"), newRate);
     });
 };

--- a/migrations/2002_setRateHigh.js
+++ b/migrations/2002_setRateHigh.js
@@ -2,11 +2,11 @@
 // run it with: "truffle migrate -f 2002 --to 2002" or "setrate:high"
 
 const Rates = artifacts.require("./Rates.sol");
-const newRate = 225000;
+const newRate = "225000";
 
-module.exports = function(deployer) {
+module.exports = function (deployer) {
     deployer.then(async () => {
-        const rates = Rates.at(Rates.address);
-        await rates.setRate("EUR", newRate);
+        const rates = await Rates.at(Rates.address);
+        await rates.setRate(web3.utils.asciiToHex("EUR"), newRate);
     });
 };

--- a/migrations_null/.eslintrc
+++ b/migrations_null/.eslintrc
@@ -1,0 +1,24 @@
+{
+    "extends": ['eslint:recommended'],
+    "parserOptions": {
+        "ecmaVersion": 2017,
+    },
+    "env": {
+        "mocha": true,
+        "node": true,
+        "es6": true
+    },
+    "rules": {
+        "indent": ["warn", 4],
+        max-len: "off",
+        radix: "off",
+        no-unused-vars: "warn",
+        "no-console": "off"
+    },
+    "globals": {
+        "web3": false,
+        "assert": false,
+        "artifacts": false,
+        "contract": false
+  }
+}

--- a/migrations_null/.prettierrc
+++ b/migrations_null/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 120,
+  "tabWidth": 4
+}

--- a/migrations_null/.readme
+++ b/migrations_null/.readme
@@ -1,3 +1,5 @@
 An empty dir to speed up test by avoiding migrations running unnecessarily again
-when yarn test runing on ganache docker container which already have all contracts
+when ganache has all the contracts already (eg. yarn test running on ganache docker container)
+This dir is set by default in truffle-config.js and --migrations_directory flag is used to override it 
+in packages.json scripts
 see: https://ethereum.stackexchange.com/a/62918/7866

--- a/migrations_null/1_no_migration.js
+++ b/migrations_null/1_no_migration.js
@@ -1,0 +1,3 @@
+module.exports = function (deployer) {
+    console.log("Skipping truffle migrations (migrations_null directory set)");
+};

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "start_comp": "yarn runmigrate_comp",
     "build": "truffle compile",
     "clean": "rm build/contracts/*",
-    "test": "truffle test --migrations_directory migrations_null",
+    "test": "truffle test",
     "coverage": "solidity-coverage",
-    "migrate": "truffle migrate",
+    "migrate": "truffle migrate --migrations_directory ./migrations",
     "compile": "yarn build",
     "ganache:run": "./scripts/runganache.sh",
     "ganache:stop": "echo TODO",
@@ -54,7 +54,6 @@
   "devDependencies": {
     "abiniser": "0.5.1",
     "babel-register": "6.26.0",
-    "bignumber.js": "5.0.0",
     "coveralls": "3.0.4",
     "dotenv": "8.0.0",
     "eslint": "6.0.0",
@@ -63,15 +62,9 @@
     "random-seed": "0.3.0",
     "solidity-coverage": "0.5.11",
     "stringifier": "2.0.0",
-    "truffle": "4.1.14",
+    "truffle": "5.1.43",
     "truffle-hdwallet-provider": "1.0.13",
-    "wait-on": "3.2.0",
-    "web3v1": "npm:web3@1.0.0-beta.34"
-  },
-  "greenkeeper": {
-    "ignore": [
-      "bignumber.js"
-    ]
+    "wait-on": "3.2.0"
   },
   "files": [
     "abiniser"

--- a/test/delegatedTransfer.js
+++ b/test/delegatedTransfer.js
@@ -3,17 +3,21 @@ const testHelpers = require("./helpers/testHelpers.js");
 const TokenAEur = artifacts.require("TokenAEur.sol");
 const FeeAccount = artifacts.require("FeeAccount.sol");
 
+const BN = web3.utils.BN;
+
 const DELEGATED_TRANSFER_MAX_GAS = 150000;
+
+let snapshotIdSingleTest;
 
 let tokenAEur;
 let from;
 
-const signDelegatedTransfer = async clientParams => {
+const signDelegatedTransfer = async (clientParams) => {
     let txHash;
 
     if (clientParams.narrative === "") {
         // workaround b/c solidity keccak256 results different txHAsh with empty string than web3
-        txHash = global.web3v1.utils.soliditySha3(
+        txHash = web3.utils.soliditySha3(
             clientParams.tokenAEurAddress,
             clientParams.from,
             clientParams.to,
@@ -22,7 +26,7 @@ const signDelegatedTransfer = async clientParams => {
             clientParams.nonce
         );
     } else {
-        txHash = global.web3v1.utils.soliditySha3(
+        txHash = web3.utils.soliditySha3(
             clientParams.tokenAEurAddress,
             clientParams.from,
             clientParams.to,
@@ -33,7 +37,7 @@ const signDelegatedTransfer = async clientParams => {
         );
     }
 
-    const signature = await global.web3v1.eth.sign(txHash, clientParams.from);
+    const signature = await web3.eth.sign(txHash, clientParams.from);
 
     return signature;
 };
@@ -45,19 +49,19 @@ const sendDelegatedTransfer = async (testInstance, clientParams, signature, exec
         from: clientParams.from,
         to: clientParams.to,
         executor: executorParams.executorAddress,
-        feeAccount: FeeAccount.address
+        feeAccount: FeeAccount.address,
     });
 
     const tx = await tokenAEur.methods
         .delegatedTransfer(
             clientParams.from,
             clientParams.to,
-            clientParams.amount,
+            clientParams.amount.toString(),
             clientParams.narrative,
-            clientParams.maxExecutorFee,
+            clientParams.maxExecutorFee.toString(),
             clientParams.nonce,
             signature,
-            executorParams.requestedExecutorFee
+            executorParams.requestedExecutorFee.toString()
         )
         .send({ from: executorParams.executorAddress, gas: 1200000 });
     testHelpers.logGasUse(testInstance, tx, "delegatedTransfer");
@@ -70,47 +74,55 @@ const sendDelegatedTransfer = async (testInstance, clientParams, signature, exec
                 .sub(clientParams.amount)
                 .sub(clientParams.fee)
                 .sub(executorParams.requestedExecutorFee),
-            eth: balBefore.from.eth
+            eth: balBefore.from.eth,
         },
         to: {
             ace: balBefore.to.ace.add(clientParams.amount),
-            eth: balBefore.to.eth
+            eth: balBefore.to.eth,
         },
         feeAccount: {
             ace: balBefore.feeAccount.ace.add(clientParams.fee),
-            eth: balBefore.feeAccount.eth
+            eth: balBefore.feeAccount.eth,
         },
         executor: {
             ace: balBefore.executor.ace.add(executorParams.requestedExecutorFee),
-            gasFee: testHelpers.GAS_PRICE * DELEGATED_TRANSFER_MAX_GAS
-        }
+            gasFee: testHelpers.GAS_PRICE * DELEGATED_TRANSFER_MAX_GAS,
+        },
     });
 
     return tx;
 };
 
-contract("Delegated Transfers", accounts => {
+contract("Delegated Transfers", (accounts) => {
     before(async () => {
         from = accounts[1];
-        tokenAEur = new global.web3v1.eth.Contract(TokenAEur.abi, TokenAEur.address);
+        tokenAEur = new web3.eth.Contract(TokenAEur.abi, TokenAEur.address);
 
         await tokenTestHelpers.issueToken(accounts[0], from, 10000);
     });
 
-    it("should transfer when delegatedTransfer is signed", async function() {
+    beforeEach(async function () {
+        snapshotIdSingleTest = await testHelpers.takeSnapshot();
+    });
+
+    afterEach(async function () {
+        await testHelpers.revertSnapshot(snapshotIdSingleTest);
+    });
+
+    it("should transfer when delegatedTransfer is signed", async function () {
         const clientParams = {
             tokenAEurAddress: TokenAEur.address,
             from,
             to: accounts[2],
-            amount: 1000,
+            amount: new BN(1000),
             narrative: "here we go",
-            maxExecutorFee: 300,
-            nonce: "0x0000000000000000000000000000000000000000000000000000000000000001" // to be a random hash with proper entrophy
+            maxExecutorFee: new BN(300),
+            nonce: "0x0000000000000000000000000000000000000000000000000000000000000001", // to be a random hash with proper entrophy
         };
 
         const executorParams = {
             executorAddress: accounts[3],
-            requestedExecutorFee: clientParams.maxExecutorFee
+            requestedExecutorFee: clientParams.maxExecutorFee,
         };
 
         const signature = await signDelegatedTransfer(clientParams);
@@ -118,20 +130,20 @@ contract("Delegated Transfers", accounts => {
         await sendDelegatedTransfer(this, clientParams, signature, executorParams);
     });
 
-    it("should not execute with the same nonce twice", async function() {
+    it("should not execute with the same nonce twice", async function () {
         const clientParams = {
             tokenAEurAddress: TokenAEur.address,
             from,
             to: accounts[2],
-            amount: 1000,
+            amount: new BN(1000),
             narrative: "here we go",
-            maxExecutorFee: 300,
-            nonce: "0x0000000000000000000000000000000000000000000000000000000000000002" // to be a random hash with proper entrophy
+            maxExecutorFee: new BN(300),
+            nonce: "0x0000000000000000000000000000000000000000000000000000000000000002", // to be a random hash with proper entrophy
         };
 
         const executorParams = {
             executorAddress: accounts[3],
-            requestedExecutorFee: clientParams.maxExecutorFee
+            requestedExecutorFee: clientParams.maxExecutorFee,
         };
 
         const signature = await signDelegatedTransfer(clientParams);
@@ -141,20 +153,20 @@ contract("Delegated Transfers", accounts => {
         await testHelpers.expectThrow(sendDelegatedTransfer(this, clientParams, signature, executorParams));
     });
 
-    it("should execute with lower requestedExecutorFee than signed", async function() {
+    it("should execute with lower requestedExecutorFee than signed", async function () {
         const clientParams = {
             tokenAEurAddress: TokenAEur.address,
             from,
             to: accounts[2],
-            amount: 1000,
+            amount: new BN(1000),
             narrative: "here we go",
-            maxExecutorFee: 300,
-            nonce: "0x0000000000000000000000000000000000000000000000000000000000000003" // to be a random hash with proper entrophy
+            maxExecutorFee: new BN(300),
+            nonce: "0x0000000000000000000000000000000000000000000000000000000000000003", // to be a random hash with proper entrophy
         };
 
         const executorParams = {
             executorAddress: accounts[3],
-            requestedExecutorFee: clientParams.maxExecutorFee - 10
+            requestedExecutorFee: clientParams.maxExecutorFee.sub(new BN(10)),
         };
 
         const signature = await signDelegatedTransfer(clientParams);
@@ -162,20 +174,20 @@ contract("Delegated Transfers", accounts => {
         await sendDelegatedTransfer(this, clientParams, signature, executorParams);
     });
 
-    it("should not execute with higher requestedExecutorFee than signed", async function() {
+    it("should not execute with higher requestedExecutorFee than signed", async function () {
         const clientParams = {
             tokenAEurAddress: TokenAEur.address,
             from,
             to: accounts[2],
-            amount: 1000,
+            amount: new BN(1000),
             narrative: "here we go",
-            maxExecutorFee: 300,
-            nonce: "0x0000000000000000000000000000000000000000000000000000000000000004" // to be a random hash with proper entrophy
+            maxExecutorFee: new BN(300),
+            nonce: "0x0000000000000000000000000000000000000000000000000000000000000004", // to be a random hash with proper entrophy
         };
 
         const executorParams = {
             executorAddress: accounts[3],
-            requestedExecutorFee: clientParams.maxExecutorFee + 1
+            requestedExecutorFee: clientParams.maxExecutorFee.add(new BN(1)),
         };
 
         const signature = await signDelegatedTransfer(clientParams);

--- a/test/delegatedTransferAndNotify.js
+++ b/test/delegatedTransferAndNotify.js
@@ -4,15 +4,19 @@ const TokenAEur = artifacts.require("TokenAEur.sol");
 const FeeAccount = artifacts.require("FeeAccount.sol");
 const Locker = artifacts.require("Locker.sol");
 
+const BN = web3.utils.BN;
+
 const DELEGATED_TRANSFERANDNOTIFY_MAX_GAS = 300000;
+
+let snapshotIdSingleTest;
 
 let tokenAEur;
 let from;
 let lockProductId;
 let perTermInterest;
 
-const signDelegatedTransferAndNotify = async clientParams => {
-    const txHash = global.web3v1.utils.soliditySha3(
+const signDelegatedTransferAndNotify = async (clientParams) => {
+    const txHash = web3.utils.soliditySha3(
         clientParams.tokenAEurAddress,
         clientParams.from,
         clientParams.target,
@@ -22,7 +26,7 @@ const signDelegatedTransferAndNotify = async clientParams => {
         clientParams.nonce
     );
 
-    const signature = await global.web3v1.eth.sign(txHash, clientParams.from);
+    const signature = await web3.eth.sign(txHash, clientParams.from);
 
     return signature;
 };
@@ -31,25 +35,25 @@ const sendDelegatedTransferAndNotify = async (testInstance, clientParams, signat
     clientParams.to = clientParams.target;
     clientParams.fee = await tokenTestHelpers.getTransferFee(clientParams);
 
-    const interestEarned = Math.ceil(clientParams.amount * perTermInterest / 1000000);
+    const interestEarned = new BN(Math.ceil((clientParams.amount * perTermInterest) / 1000000));
 
     const balBefore = await tokenTestHelpers.getAllBalances({
         from: clientParams.from,
         target: clientParams.target,
         executor: executorParams.executorAddress,
-        feeAccount: FeeAccount.address
+        feeAccount: FeeAccount.address,
     });
 
     const tx = await tokenAEur.methods
         .delegatedTransferAndNotify(
             clientParams.from,
             clientParams.target,
-            clientParams.amount,
+            clientParams.amount.toString(),
             clientParams.data,
-            clientParams.maxExecutorFee,
+            clientParams.maxExecutorFee.toString(),
             clientParams.nonce,
             signature,
-            executorParams.requestedExecutorFee
+            executorParams.requestedExecutorFee.toString()
         )
         .send({ from: executorParams.executorAddress, gas: 1200000 });
     testHelpers.logGasUse(testInstance, tx, "delegatedTransferAndNotify");
@@ -62,52 +66,60 @@ const sendDelegatedTransferAndNotify = async (testInstance, clientParams, signat
                 .sub(clientParams.amount)
                 .sub(clientParams.fee)
                 .sub(executorParams.requestedExecutorFee),
-            eth: balBefore.from.eth
+            eth: balBefore.from.eth,
         },
         target: {
             ace: balBefore.target.ace.add(clientParams.amount).add(interestEarned),
-            eth: balBefore.target.eth
+            eth: balBefore.target.eth,
         },
         feeAccount: {
             ace: balBefore.feeAccount.ace.add(clientParams.fee),
-            eth: balBefore.feeAccount.eth
+            eth: balBefore.feeAccount.eth,
         },
         executor: {
             ace: balBefore.executor.ace.add(executorParams.requestedExecutorFee),
-            gasFee: testHelpers.GAS_PRICE * DELEGATED_TRANSFERANDNOTIFY_MAX_GAS
-        }
+            gasFee: testHelpers.GAS_PRICE * DELEGATED_TRANSFERANDNOTIFY_MAX_GAS,
+        },
     });
 
     return tx;
 };
 
-contract("Delegated transferAndNotify", accounts => {
+contract("Delegated transferAndNotify", (accounts) => {
     before(async () => {
         from = accounts[1];
         lockProductId = 0;
-        tokenAEur = new global.web3v1.eth.Contract(TokenAEur.abi, TokenAEur.address);
+        tokenAEur = new web3.eth.Contract(TokenAEur.abi, TokenAEur.address);
 
-        const lockerInstance = Locker.at(Locker.address);
+        const lockerInstance = await Locker.at(Locker.address);
         const product = await lockerInstance.lockProducts(0);
         perTermInterest = product[0].toNumber();
 
         await tokenTestHelpers.issueToken(accounts[0], from, 10000);
     });
 
-    it("should lock with delegatedTransferAndNotify", async function() {
+    beforeEach(async function () {
+        snapshotIdSingleTest = await testHelpers.takeSnapshot();
+    });
+
+    afterEach(async function () {
+        await testHelpers.revertSnapshot(snapshotIdSingleTest);
+    });
+
+    it("should lock with delegatedTransferAndNotify", async function () {
         const clientParams = {
             tokenAEurAddress: TokenAEur.address,
             from,
             target: Locker.address,
-            amount: 1000,
+            amount: new BN(1000),
             data: lockProductId,
-            maxExecutorFee: 300,
-            nonce: "0x0000000000000000000000000000000000000000000000000000000000000001" // to be a random hash with proper entrophy
+            maxExecutorFee: new BN(300),
+            nonce: "0x0000000000000000000000000000000000000000000000000000000000000001", // to be a random hash with proper entrophy
         };
 
         const executorParams = {
             executorAddress: accounts[3],
-            requestedExecutorFee: clientParams.maxExecutorFee
+            requestedExecutorFee: clientParams.maxExecutorFee,
         };
 
         const signature = await signDelegatedTransferAndNotify(clientParams);
@@ -115,20 +127,20 @@ contract("Delegated transferAndNotify", accounts => {
         await sendDelegatedTransferAndNotify(this, clientParams, signature, executorParams);
     });
 
-    it("should not execute with the same nonce twice", async function() {
+    it("should not execute with the same nonce twice", async function () {
         const clientParams = {
             tokenAEurAddress: TokenAEur.address,
             from,
             target: Locker.address,
-            amount: 1000,
+            amount: new BN(1000),
             data: lockProductId,
-            maxExecutorFee: 300,
-            nonce: "0x0000000000000000000000000000000000000000000000000000000000000002" // to be a random hash with proper entrophy
+            maxExecutorFee: new BN(300),
+            nonce: "0x0000000000000000000000000000000000000000000000000000000000000002", // to be a random hash with proper entrophy
         };
 
         const executorParams = {
             executorAddress: accounts[3],
-            requestedExecutorFee: clientParams.maxExecutorFee
+            requestedExecutorFee: clientParams.maxExecutorFee,
         };
 
         const signature = await signDelegatedTransferAndNotify(clientParams);
@@ -138,20 +150,20 @@ contract("Delegated transferAndNotify", accounts => {
         await testHelpers.expectThrow(sendDelegatedTransferAndNotify(this, clientParams, signature, executorParams));
     });
 
-    it("should execute with lower requestedExecutorFee than signed", async function() {
+    it("should execute with lower requestedExecutorFee than signed", async function () {
         const clientParams = {
             tokenAEurAddress: TokenAEur.address,
             from,
             target: Locker.address,
-            amount: 1000,
+            amount: new BN(1000),
             data: lockProductId,
-            maxExecutorFee: 300,
-            nonce: "0x0000000000000000000000000000000000000000000000000000000000000003" // to be a random hash with proper entrophy
+            maxExecutorFee: new BN(300),
+            nonce: "0x0000000000000000000000000000000000000000000000000000000000000003", // to be a random hash with proper entrophy
         };
 
         const executorParams = {
             executorAddress: accounts[3],
-            requestedExecutorFee: clientParams.maxExecutorFee - 10
+            requestedExecutorFee: clientParams.maxExecutorFee.sub(new BN(10)),
         };
 
         const signature = await signDelegatedTransferAndNotify(clientParams);
@@ -159,20 +171,20 @@ contract("Delegated transferAndNotify", accounts => {
         await sendDelegatedTransferAndNotify(this, clientParams, signature, executorParams);
     });
 
-    it("should not execute with higher requestedExecutorFee than signed", async function() {
+    it("should not execute with higher requestedExecutorFee than signed", async function () {
         const clientParams = {
             tokenAEurAddress: TokenAEur.address,
             from,
             target: Locker.address,
-            amount: 1000,
+            amount: new BN(1000),
             data: lockProductId,
-            maxExecutorFee: 300,
-            nonce: "0x0000000000000000000000000000000000000000000000000000000000000004" // to be a random hash with proper entrophy
+            maxExecutorFee: new BN(300),
+            nonce: "0x0000000000000000000000000000000000000000000000000000000000000004", // to be a random hash with proper entrophy
         };
 
         const executorParams = {
             executorAddress: accounts[3],
-            requestedExecutorFee: clientParams.maxExecutorFee + 1
+            requestedExecutorFee: clientParams.maxExecutorFee.add(new BN(1)),
         };
 
         const signature = await signDelegatedTransferAndNotify(clientParams);

--- a/test/exchange.js
+++ b/test/exchange.js
@@ -4,25 +4,26 @@ const ratesTestHelpers = require("./helpers/ratesTestHelpers.js");
 
 let exchange = null;
 
-contract("Exchange tests", accounts => {
-    before(async function() {
+contract("Exchange tests", (accounts) => {
+    before(async function () {
         exchange = exchangeTestHelpers.exchange;
     });
 
-    it("Should allow to change rates contract", async function() {
-        const newRatesContract = ratesTestHelpers.rates.address;
-        const tx = await exchange.setRatesContract(newRatesContract);
+    it("Should allow to change rates contract", async function () {
+        const newRatesContract = accounts[0];
+
+        const tx = await exchange.setRatesContract(accounts[0]);
         testHelpers.logGasUse(this, tx, "setRatesContract");
 
         const [actualRatesContract] = await Promise.all([
             exchange.rates(),
-            testHelpers.assertEvent(exchange, "RatesContractChanged", { newRatesContract })
+            testHelpers.assertEvent(exchange, "RatesContractChanged", { newRatesContract }),
         ]);
 
         assert.equal(actualRatesContract, newRatesContract);
     });
 
-    it("Only allowed should change rates and monetarySupervisor contracts", async function() {
+    it("Only allowed should change rates and monetarySupervisor contracts", async function () {
         const newRatesContract = ratesTestHelpers.rates.address;
         await testHelpers.expectThrow(exchange.setRatesContract(newRatesContract, { from: accounts[1] }));
     });

--- a/test/exchangeMatchMultiple.js
+++ b/test/exchangeMatchMultiple.js
@@ -10,14 +10,14 @@ let exchange = null;
 let maker;
 let taker;
 
-contract("Exchange Multiple Matching tests", () => {
+contract("Exchange Multiple Matching tests", (accounts) => {
     before(async function () {
         exchange = exchangeTestHelper.exchange;
-        maker = global.accounts[1];
-        taker = global.accounts[2];
+        maker = accounts[1];
+        taker = accounts[2];
         await Promise.all([
-            tokenTestHelpers.issueToken(global.accounts[0], maker, 1000000),
-            tokenTestHelpers.issueToken(global.accounts[0], taker, 1000000),
+            tokenTestHelpers.issueToken(accounts[0], maker, 1000000),
+            tokenTestHelpers.issueToken(accounts[0], taker, 1000000),
         ]);
     });
 

--- a/test/exchangeMatchMultiple.js
+++ b/test/exchangeMatchMultiple.js
@@ -11,51 +11,53 @@ let maker;
 let taker;
 
 contract("Exchange Multiple Matching tests", () => {
-    before(async function() {
+    before(async function () {
         exchange = exchangeTestHelper.exchange;
         maker = global.accounts[1];
         taker = global.accounts[2];
-        await tokenTestHelpers.issueToken(global.accounts[0], maker, 1000000);
-        await tokenTestHelpers.issueToken(global.accounts[0], taker, 1000000);
+        await Promise.all([
+            tokenTestHelpers.issueToken(global.accounts[0], maker, 1000000),
+            tokenTestHelpers.issueToken(global.accounts[0], taker, 1000000),
+        ]);
     });
 
-    beforeEach(async function() {
+    beforeEach(async function () {
         snapshotId = await testHelpers.takeSnapshot();
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
         await testHelpers.revertSnapshot(snapshotId);
     });
 
-    it("should match multiple sell orders", async function() {
+    it("should match multiple sell orders", async function () {
         const makerPrice = 1010000;
         const tokenAmount = 10000;
 
         const buyOrder1 = {
-            amount: global.web3v1.utils.toWei("10"),
+            amount: web3.utils.toWei("10"),
             maker: maker,
-            price: makerPrice,
-            orderType: TOKEN_BUY
+            price: makerPrice.toString(),
+            orderType: TOKEN_BUY,
         };
         const buyOrder2 = {
-            amount: global.web3v1.utils.toWei("20"),
+            amount: web3.utils.toWei("20"),
             maker: maker,
-            price: makerPrice,
-            orderType: TOKEN_BUY
+            price: makerPrice.toString(),
+            orderType: TOKEN_BUY,
         };
         const sellOrder1 = {
             amount: tokenAmount,
             maker: taker,
-            price: 990000,
-            orderType: TOKEN_SELL
+            price: "990000",
+            orderType: TOKEN_SELL,
         };
         const sellOrder2 = Object.assign({}, sellOrder1);
         const sellOrder3 = Object.assign({}, sellOrder1);
 
         await exchangeTestHelper.newOrder(this, buyOrder1);
         await exchangeTestHelper.newOrder(this, buyOrder2);
-        await exchangeTestHelper.newOrder(this, sellOrder1),
-        await exchangeTestHelper.newOrder(this, sellOrder2),
+        await exchangeTestHelper.newOrder(this, sellOrder1);
+        await exchangeTestHelper.newOrder(this, sellOrder2);
         await exchangeTestHelper.newOrder(this, sellOrder3);
 
         // await exchangeTestHelper.printOrderBook(10);
@@ -74,62 +76,62 @@ contract("Exchange Multiple Matching tests", () => {
 
         await testHelpers.assertEvent(exchange, "OrderFill", [
             {
-                sellTokenOrderId: sellOrder1.id,
-                buyTokenOrderId: buyOrder1.id,
+                sellTokenOrderId: sellOrder1.id.toString(),
+                buyTokenOrderId: buyOrder1.id.toString(),
                 tokenSeller: taker,
                 tokenBuyer: maker,
                 publishedRate: () => {}, // ignore, not testing it here,
-                price: makerPrice,
+                price: makerPrice.toString(),
                 weiAmount: () => {}, // ignore, not testing it here
-                tokenAmount: tokenAmount
+                tokenAmount: tokenAmount.toString(),
             },
             {
-                sellTokenOrderId: sellOrder2.id,
-                buyTokenOrderId: buyOrder2.id,
+                sellTokenOrderId: sellOrder2.id.toString(),
+                buyTokenOrderId: buyOrder2.id.toString(),
                 tokenSeller: taker,
                 tokenBuyer: maker,
                 publishedRate: () => {}, // ignore, not testing it here,
-                price: makerPrice,
+                price: makerPrice.toString(),
                 weiAmount: () => {}, // ignore, not testing it here
-                tokenAmount: tokenAmount
+                tokenAmount: tokenAmount.toString(),
             },
             {
-                sellTokenOrderId: sellOrder3.id,
-                buyTokenOrderId: buyOrder1.id,
+                sellTokenOrderId: sellOrder3.id.toString(),
+                buyTokenOrderId: buyOrder1.id.toString(),
                 tokenSeller: taker,
                 tokenBuyer: maker,
                 publishedRate: () => {}, // ignore, not testing it here,
-                price: makerPrice,
+                price: makerPrice.toString(),
                 weiAmount: () => {}, // ignore, not testing it here
-                tokenAmount: tokenAmount
-            }
+                tokenAmount: tokenAmount.toString(),
+            },
         ]);
     });
 
     // ensure edge cases of passing the same order twice
-    it("matchMultipleOrders should match as many orders as fits into gas provided", async function() {
+    it("matchMultipleOrders should match as many orders as fits into gas provided", async function () {
         const makerPrice = 1010000;
         const tokenAmount = 10000;
         const buyOrder = {
-            amount: global.web3v1.utils.toWei("10"),
+            amount: web3.utils.toWei("10"),
             maker: maker,
-            price: makerPrice,
-            orderType: TOKEN_BUY
+            price: makerPrice.toString(),
+            orderType: TOKEN_BUY,
         };
 
         const sellOrder1 = {
             amount: tokenAmount,
             maker: taker,
-            price: 990000,
-            orderType: TOKEN_SELL
+            price: "990000",
+            orderType: TOKEN_SELL,
         };
         const sellOrder2 = Object.assign({}, sellOrder1);
         const sellOrder3 = Object.assign({}, sellOrder1);
         const sellOrder4 = Object.assign({}, sellOrder1);
 
         await exchangeTestHelper.newOrder(this, buyOrder);
-        await exchangeTestHelper.newOrder(this, sellOrder1),
-        await exchangeTestHelper.newOrder(this, sellOrder2),
+        await exchangeTestHelper.newOrder(this, sellOrder1);
+        await exchangeTestHelper.newOrder(this, sellOrder2);
         await exchangeTestHelper.newOrder(this, sellOrder3);
         await exchangeTestHelper.newOrder(this, sellOrder4);
 
@@ -147,35 +149,35 @@ contract("Exchange Multiple Matching tests", () => {
 
         await testHelpers.assertEvent(exchange, "OrderFill", [
             {
-                sellTokenOrderId: sellOrder1.id,
-                buyTokenOrderId: buyOrder.id,
+                sellTokenOrderId: sellOrder1.id.toString(),
+                buyTokenOrderId: buyOrder.id.toString(),
                 tokenSeller: taker,
                 tokenBuyer: maker,
                 publishedRate: () => {}, // ignore, not testing it here,
-                price: makerPrice,
+                price: makerPrice.toString(),
                 weiAmount: () => {}, // ignore, not testing it here
-                tokenAmount: tokenAmount
+                tokenAmount: tokenAmount.toString(),
             },
             {
-                sellTokenOrderId: sellOrder2.id,
-                buyTokenOrderId: buyOrder.id,
+                sellTokenOrderId: sellOrder2.id.toString(),
+                buyTokenOrderId: buyOrder.id.toString(),
                 tokenSeller: taker,
                 tokenBuyer: maker,
                 publishedRate: () => {}, // ignore, not testing it here,
-                price: makerPrice,
+                price: makerPrice.toString(),
                 weiAmount: () => {}, // ignore, not testing it here
-                tokenAmount: tokenAmount
+                tokenAmount: tokenAmount.toString(),
             },
             {
-                sellTokenOrderId: sellOrder3.id,
-                buyTokenOrderId: buyOrder.id,
+                sellTokenOrderId: sellOrder3.id.toString(),
+                buyTokenOrderId: buyOrder.id.toString(),
                 tokenSeller: taker,
                 tokenBuyer: maker,
                 publishedRate: () => {}, // ignore, not testing it here,
-                price: makerPrice,
+                price: makerPrice.toString(),
                 weiAmount: () => {}, // ignore, not testing it here
-                tokenAmount: tokenAmount
-            }
+                tokenAmount: tokenAmount.toString(),
+            },
         ]);
 
         const stateAfter = await exchangeTestHelper.getState();
@@ -183,34 +185,34 @@ contract("Exchange Multiple Matching tests", () => {
         assert.equal(stateAfter.buyCount, 1, "Buy token order count should be 1");
     });
 
-    it("matchMultipleOrders should carry on if one is duplicate, non-matching or removed", async function() {
+    it("matchMultipleOrders should carry on if one is duplicate, non-matching or removed", async function () {
         const makerPrice = 1010000;
         const tokenAmount = 10000;
         const buyOrder = {
-            amount: global.web3v1.utils.toWei("10"),
+            amount: web3.utils.toWei("10"),
             maker: maker,
-            price: makerPrice,
-            orderType: TOKEN_BUY
+            price: makerPrice.toString(),
+            orderType: TOKEN_BUY,
         };
         const sellOrder1 = {
-            amount: tokenAmount,
+            amount: tokenAmount.toString(),
             maker: taker,
-            price: 990000,
-            orderType: TOKEN_SELL
+            price: "990000",
+            orderType: TOKEN_SELL,
         };
         const sellOrder2Cancelled = Object.assign({}, sellOrder1);
         const sellOrder3 = Object.assign({}, sellOrder1);
         const sellOrder4Matched = Object.assign({}, sellOrder1);
 
         await exchangeTestHelper.newOrder(this, buyOrder);
-        await exchangeTestHelper.newOrder(this, sellOrder1),
-        await exchangeTestHelper.newOrder(this, sellOrder2Cancelled),
+        await exchangeTestHelper.newOrder(this, sellOrder1);
+        await exchangeTestHelper.newOrder(this, sellOrder2Cancelled);
         await exchangeTestHelper.newOrder(this, sellOrder3);
         await exchangeTestHelper.newOrder(this, sellOrder4Matched);
 
         await Promise.all([
             exchange.cancelSellTokenOrder(sellOrder2Cancelled.id, { from: sellOrder2Cancelled.maker }),
-            exchange.matchOrders(buyOrder.id, sellOrder4Matched.id)
+            exchange.matchOrders(buyOrder.id, sellOrder4Matched.id),
         ]);
 
         // await exchangeTestHelper.printOrderBook(10);
@@ -227,26 +229,26 @@ contract("Exchange Multiple Matching tests", () => {
 
         await testHelpers.assertEvent(exchange, "OrderFill", [
             {
-                sellTokenOrderId: sellOrder1.id,
-                buyTokenOrderId: buyOrder.id,
+                sellTokenOrderId: sellOrder1.id.toString(),
+                buyTokenOrderId: buyOrder.id.toString(),
                 tokenSeller: taker,
                 tokenBuyer: maker,
                 publishedRate: () => {}, // ignore, not testing it here,
-                price: makerPrice,
+                price: makerPrice.toString(),
                 weiAmount: () => {}, // ignore, not testing it here
-                tokenAmount: tokenAmount
+                tokenAmount: tokenAmount.toString(),
             },
 
             {
-                sellTokenOrderId: sellOrder3.id,
-                buyTokenOrderId: buyOrder.id,
+                sellTokenOrderId: sellOrder3.id.toString(),
+                buyTokenOrderId: buyOrder.id.toString(),
                 tokenSeller: taker,
                 tokenBuyer: maker,
                 publishedRate: () => {}, // ignore, not testing it here,
-                price: makerPrice,
+                price: makerPrice.toString(),
                 weiAmount: () => {}, // ignore, not testing it here
-                tokenAmount: tokenAmount
-            }
+                tokenAmount: tokenAmount.toString(),
+            },
         ]);
 
         const stateAfter = await exchangeTestHelper.getState();

--- a/test/exchangeMatching.js
+++ b/test/exchangeMatching.js
@@ -11,7 +11,7 @@ let maker;
 let taker;
 
 contract("Exchange matching tests", () => {
-    before(async function() {
+    before(async function () {
         exchange = exchangeTestHelper.exchange;
         maker = global.accounts[1];
         taker = global.accounts[2];
@@ -19,26 +19,26 @@ contract("Exchange matching tests", () => {
         await tokenTestHelpers.issueToken(global.accounts[0], taker, 1000000);
     });
 
-    beforeEach(async function() {
+    beforeEach(async function () {
         snapshotId = await testHelpers.takeSnapshot();
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
         await testHelpers.revertSnapshot(snapshotId);
     });
 
-    it("should match two matching orders (buy token fully filled)", async function() {
+    it("should match two matching orders (buy token fully filled)", async function () {
         const buyOrder = {
-            amount: global.web3v1.utils.toWei("0.535367"),
+            amount: web3.utils.toWei("0.535367"),
             maker: maker,
             price: 1010000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
         const sellOrder = {
             amount: 95582,
             maker: taker,
             price: 990000,
-            orderType: TOKEN_SELL
+            orderType: TOKEN_SELL,
         };
 
         await exchangeTestHelper.newOrder(this, buyOrder);
@@ -51,18 +51,18 @@ contract("Exchange matching tests", () => {
         assert.equal(stateAfter.buyCount, 0, "Buy token order count should be 0");
     });
 
-    it("should match two matching orders (sell token fully filled)", async function() {
+    it("should match two matching orders (sell token fully filled)", async function () {
         const buyOrder = {
-            amount: global.web3v1.utils.toWei("1.7504"),
+            amount: web3.utils.toWei("1.7504"),
             maker: maker,
             price: 1010000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
         const sellOrder = {
             amount: 56141,
             maker: taker,
             price: 990000,
-            orderType: TOKEN_SELL
+            orderType: TOKEN_SELL,
         };
 
         await exchangeTestHelper.newOrder(this, buyOrder);
@@ -75,12 +75,12 @@ contract("Exchange matching tests", () => {
         assert.equal(stateAfter.buyCount, 1, "Buy token order count should be 1");
     });
 
-    it("should fail if trying to match a sell order with 0 amount left", async function() {
+    it("should fail if trying to match a sell order with 0 amount left", async function () {
         const buyOrder = {
-            amount: global.web3v1.utils.toWei("1.7504"),
+            amount: web3.utils.toWei("1.7504"),
             maker: maker,
             price: 1010000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
         const buyOrder2 = Object.assign({}, buyOrder);
         const sellOrder = { amount: 56141, maker: taker, price: 990000, orderType: TOKEN_SELL };
@@ -104,12 +104,12 @@ contract("Exchange matching tests", () => {
         await testHelpers.expectThrow(exchange.matchOrders(buyOrder.id, sellOrder.id));
     });
 
-    it("should fail if trying to match a buy order with 0 amount left", async function() {
+    it("should fail if trying to match a buy order with 0 amount left", async function () {
         const buyOrder = {
-            amount: global.web3v1.utils.toWei("0.0504"),
+            amount: web3.utils.toWei("0.0504"),
             maker: maker,
             price: 1010000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
         const sellOrder = { amount: 56141, maker: taker, price: 990000, orderType: TOKEN_SELL };
         const buyOrder2 = Object.assign({}, buyOrder);
@@ -133,8 +133,8 @@ contract("Exchange matching tests", () => {
         await testHelpers.expectThrow(exchange.matchOrders(buyOrder.id, sellOrder.id));
     });
 
-    it("should fail if trying to match two orders with 0 amount left", async function() {
-        const buyOrder = { amount: global.web3v1.utils.toWei("1"), maker: maker, price: 1000000, orderType: TOKEN_BUY };
+    it("should fail if trying to match two orders with 0 amount left", async function () {
+        const buyOrder = { amount: web3.utils.toWei("1"), maker: maker, price: 1000000, orderType: TOKEN_BUY };
         const sellOrder = { amount: 99800, maker: maker, price: 990000, orderType: TOKEN_SELL };
         const buyOrder2 = Object.assign({}, buyOrder);
         const sellOrder2 = Object.assign({}, sellOrder);
@@ -157,8 +157,8 @@ contract("Exchange matching tests", () => {
         await testHelpers.expectThrow(exchange.matchOrders(buyOrder.id, sellOrder.id));
     });
 
-    it("should match two matching orders (both fully filled)", async function() {
-        const buyOrder = { amount: global.web3v1.utils.toWei("1"), maker: maker, price: 1000000, orderType: TOKEN_BUY };
+    it("should match two matching orders (both fully filled)", async function () {
+        const buyOrder = { amount: web3.utils.toWei("1"), maker: maker, price: 1000000, orderType: TOKEN_BUY };
         const sellOrder = { amount: 99800, maker: maker, price: 990000, orderType: TOKEN_SELL };
 
         await exchangeTestHelper.newOrder(this, buyOrder);
@@ -171,16 +171,16 @@ contract("Exchange matching tests", () => {
         assert.equal(stateAfter.buyCount, 0, "Buy token order count should be 0");
     });
 
-    it("should fully fill both orders when buy token amount expected to be same as sell token amount", async function() {
+    it("should fully fill both orders when buy token amount expected to be same as sell token amount", async function () {
         /* from users perspective:
          Sell: 100A€ / 998 A€/ETH = 0.1002004008 ETH
          Buy: 0.1002004008 ETH * 998 A€/ETH = 99.9999999984 A€ wich is 100A€ b/c A€ is w/ 2 decimals
         */
         const buyOrder = {
-            amount: global.web3v1.utils.toWei("0.1002004008"),
+            amount: web3.utils.toWei("0.1002004008"),
             maker: maker,
             price: 1000000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
         const sellOrder = { amount: 10000, maker: maker, price: 1000000, orderType: TOKEN_SELL };
 
@@ -196,12 +196,12 @@ contract("Exchange matching tests", () => {
         assert.equal(stateAfter.buyCount, 0, "Buy token order count should be 0");
     });
 
-    it("should match two matching orders from the same account on sell price if placed first ", async function() {
+    it("should match two matching orders from the same account on sell price if placed first ", async function () {
         const buyOrder = {
-            amount: global.web3v1.utils.toWei("1.7504"),
+            amount: web3.utils.toWei("1.7504"),
             maker: maker,
             price: 1010000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
         const sellOrder = { amount: 56141, maker: maker, price: 990000, orderType: TOKEN_SELL };
 
@@ -215,13 +215,13 @@ contract("Exchange matching tests", () => {
         assert.equal(stateAfter.buyCount, 1, "Buy token order count should be 1");
     });
 
-    it("should NOT match two non-matching orders", async function() {
+    it("should NOT match two non-matching orders", async function () {
         // buy price lower then sell price, should fail
         const buyOrder = {
-            amount: global.web3v1.utils.toWei("1.7504"),
+            amount: web3.utils.toWei("1.7504"),
             maker: maker,
             price: 1010000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
         const sellOrder = { amount: 56141, maker: maker, price: 1010001, orderType: TOKEN_SELL };
 
@@ -230,12 +230,12 @@ contract("Exchange matching tests", () => {
         await testHelpers.expectThrow(exchange.matchOrders(buyOrder.id, sellOrder.id));
     });
 
-    it("shouldn't matchmultiple if different count of buy&sell orders passed ", async function() {
+    it("shouldn't matchmultiple if different count of buy&sell orders passed ", async function () {
         const buyOrder1 = {
-            amount: global.web3v1.utils.toWei("0.535367"),
+            amount: web3.utils.toWei("0.535367"),
             maker: maker,
             price: 1010000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
         const sellOrder1 = { amount: 95582, maker: taker, price: 900000, orderType: TOKEN_SELL };
         const sellOrder2 = { amount: 95582, maker: taker, price: 900000, orderType: TOKEN_SELL };

--- a/test/exchangeMatching.js
+++ b/test/exchangeMatching.js
@@ -10,13 +10,13 @@ let exchange = null;
 let maker;
 let taker;
 
-contract("Exchange matching tests", () => {
+contract("Exchange matching tests", (accounts) => {
     before(async function () {
         exchange = exchangeTestHelper.exchange;
-        maker = global.accounts[1];
-        taker = global.accounts[2];
-        await tokenTestHelpers.issueToken(global.accounts[0], maker, 1000000);
-        await tokenTestHelpers.issueToken(global.accounts[0], taker, 1000000);
+        maker = accounts[1];
+        taker = accounts[2];
+        await tokenTestHelpers.issueToken(accounts[0], maker, 1000000);
+        await tokenTestHelpers.issueToken(accounts[0], taker, 1000000);
     });
 
     beforeEach(async function () {

--- a/test/exchangeOrders.js
+++ b/test/exchangeOrders.js
@@ -15,7 +15,7 @@ let exchange = null;
 
 contract("Exchange orders tests", (accounts) => {
     before(async function () {
-        makers = [global.accounts[1], global.accounts[2], global.accounts[3]];
+        makers = [accounts[1], accounts[2], accounts[3]];
         exchange = exchangeTestHelpers.exchange;
         augmintToken = tokenTestHelpers.augmintToken;
         await Promise.all(makers.map((maker) => tokenTestHelpers.issueToken(accounts[0], maker, 1000000)));

--- a/test/exchangeOrders.js
+++ b/test/exchangeOrders.js
@@ -13,28 +13,28 @@ let snapshotId;
 let augmintToken = null;
 let exchange = null;
 
-contract("Exchange orders tests", accounts => {
-    before(async function() {
+contract("Exchange orders tests", (accounts) => {
+    before(async function () {
         makers = [global.accounts[1], global.accounts[2], global.accounts[3]];
         exchange = exchangeTestHelpers.exchange;
         augmintToken = tokenTestHelpers.augmintToken;
-        await Promise.all(makers.map(maker => tokenTestHelpers.issueToken(accounts[0], maker, 1000000)));
+        await Promise.all(makers.map((maker) => tokenTestHelpers.issueToken(accounts[0], maker, 1000000)));
     });
 
-    beforeEach(async function() {
+    beforeEach(async function () {
         snapshotId = await testHelpers.takeSnapshot();
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
         await testHelpers.revertSnapshot(snapshotId);
     });
 
-    it("place buy token orders", async function() {
+    it("place buy token orders", async function () {
         const order = {
-            amount: global.web3v1.utils.toWei("1"),
+            amount: web3.utils.toWei("1"),
             maker: makers[0],
             price: 1000000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
 
         await exchangeTestHelpers.newOrder(this, order);
@@ -42,13 +42,13 @@ contract("Exchange orders tests", accounts => {
         //await exchangeTestHelper.printOrderBook();
     });
 
-    it("place sell token orders directly on Exchange", async function() {
+    it("place sell token orders directly on Exchange", async function () {
         const order = {
             amount: 10000,
             maker: makers[0],
             price: 1010000,
             orderType: TOKEN_SELL,
-            viaAugmintToken: false
+            viaAugmintToken: false,
         };
 
         const tx = await augmintToken.approve(exchange.address, order.amount * 2, { from: order.maker });
@@ -58,13 +58,13 @@ contract("Exchange orders tests", accounts => {
         await exchangeTestHelpers.newOrder(this, order);
     });
 
-    it("shouldn't place a sell token order directly if approval < amount", async function() {
+    it("shouldn't place a sell token order directly if approval < amount", async function () {
         const order = {
             amount: 10000,
             maker: makers[0],
             price: 1010000,
             orderType: TOKEN_SELL,
-            viaAugmintToken: false
+            viaAugmintToken: false,
         };
 
         const tx = await augmintToken.approve(exchange.address, order.amount - 1, { from: order.maker });
@@ -73,42 +73,42 @@ contract("Exchange orders tests", accounts => {
         await testHelpers.expectThrow(exchange.placeSellTokenOrder(order.price, order.amount, { from: order.maker }));
     });
 
-    it("place a sell token order via AugmintToken", async function() {
+    it("place a sell token order via AugmintToken", async function () {
         const order = { amount: 10000, maker: makers[0], price: 1010000, orderType: TOKEN_SELL };
 
         await exchangeTestHelpers.newOrder(this, order);
         await exchangeTestHelpers.newOrder(this, order);
     });
 
-    it("should place a BUY token order", async function() {
+    it("should place a BUY token order", async function () {
         const order = { amount: 10000, maker: makers[0], price: 1010000, orderType: TOKEN_BUY };
 
         await exchangeTestHelpers.newOrder(this, order);
     });
 
-    it("shouldn't place a SELL token order with 0 tokens", async function() {
+    it("shouldn't place a SELL token order with 0 tokens", async function () {
         const price = 1010000;
         await testHelpers.expectThrow(augmintToken.transferAndNotify(exchange.address, 0, price, { from: makers[0] }));
     });
 
-    it("shouldn't place a SELL token order with 0 price", async function() {
+    it("shouldn't place a SELL token order with 0 price", async function () {
         const price = 0;
         await testHelpers.expectThrow(
             augmintToken.transferAndNotify(exchange.address, 1000, price, { from: makers[0] })
         );
     });
 
-    it("shouldn't place a BUY token order with 0 ETH", async function() {
+    it("shouldn't place a BUY token order with 0 ETH", async function () {
         const price = 1010000;
         await testHelpers.expectThrow(exchange.placeBuyTokenOrder(price, { value: 0 }));
     });
 
-    it("shouldn't place a BUY token order with 0 price", async function() {
+    it("shouldn't place a BUY token order with 0 price", async function () {
         const price = 0;
-        await testHelpers.expectThrow(exchange.placeBuyTokenOrder(price, { value: global.web3v1.utils.toWei("0.1") }));
+        await testHelpers.expectThrow(exchange.placeBuyTokenOrder(price, { value: web3.utils.toWei("0.1") }));
     });
 
-    it("no SELL token order when user doesn't have enough ACE", async function() {
+    it("no SELL token order when user doesn't have enough ACE", async function () {
         const price = 1010000;
         const userBal = await augmintToken.balanceOf(makers[0]);
         await testHelpers.expectThrow(
@@ -116,24 +116,24 @@ contract("Exchange orders tests", accounts => {
         );
     });
 
-    it("should remove the proper buy orders from the active list", async function() {
+    it("should remove the proper buy orders from the active list", async function () {
         const orderA = {
-            amount: global.web3v1.utils.toWei("1"),
+            amount: web3.utils.toWei("1"),
             maker: makers[0],
             price: 1100000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
         const orderB = {
-            amount: global.web3v1.utils.toWei("2"),
+            amount: web3.utils.toWei("2"),
             maker: makers[1],
             price: 1200000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
         const orderC = {
-            amount: global.web3v1.utils.toWei("3"),
+            amount: web3.utils.toWei("3"),
             maker: makers[2],
             price: 1300000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
 
         await exchangeTestHelpers.newOrder(this, orderA);
@@ -154,24 +154,24 @@ contract("Exchange orders tests", accounts => {
         assert.equal(activeBuys[0].id, orderB.id, "wrong ID in active orders list");
     });
 
-    it("should remove the proper sell orders from the active list", async function() {
+    it("should remove the proper sell orders from the active list", async function () {
         const orderA = {
             amount: 1000,
             maker: makers[0],
             price: 1100000,
-            orderType: TOKEN_SELL
+            orderType: TOKEN_SELL,
         };
         const orderB = {
             amount: 2000,
             maker: makers[1],
             price: 1200000,
-            orderType: TOKEN_SELL
+            orderType: TOKEN_SELL,
         };
         const orderC = {
             amount: 3000,
             maker: makers[2],
             price: 1300000,
-            orderType: TOKEN_SELL
+            orderType: TOKEN_SELL,
         };
 
         await exchangeTestHelpers.newOrder(this, orderA);
@@ -192,26 +192,26 @@ contract("Exchange orders tests", accounts => {
         assert.equal(activeSells[0].id, orderB.id, "wrong ID in active orders list");
     });
 
-    it("should cancel a BUY token order", async function() {
+    it("should cancel a BUY token order", async function () {
         const order = {
-            amount: global.web3v1.utils.toWei("1"),
+            amount: web3.utils.toWei("1"),
             maker: makers[0],
             price: 1010000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
 
         await exchangeTestHelpers.newOrder(this, order);
         await exchangeTestHelpers.cancelOrder(this, order);
     });
 
-    it("should cancel a SELL token order", async function() {
+    it("should cancel a SELL token order", async function () {
         const order = { amount: 10000, maker: makers[0], price: 1010000, orderType: TOKEN_SELL };
 
         await exchangeTestHelpers.newOrder(this, order);
         await exchangeTestHelpers.cancelOrder(this, order);
     });
 
-    it("should fail when cancelling an already deleted sell order", async function() {
+    it("should fail when cancelling an already deleted sell order", async function () {
         const sellOrder1 = { amount: 45454, maker: makers[0], price: 1010000, orderType: TOKEN_SELL };
         const sellOrder2 = { amount: 45454, maker: makers[0], price: 1010000, orderType: TOKEN_SELL };
 
@@ -220,18 +220,18 @@ contract("Exchange orders tests", accounts => {
         await testHelpers.expectThrow(exchange.cancelSellTokenOrder(sellOrder2.id));
     });
 
-    it("should fail when cancelling an already deleted buy order", async function() {
+    it("should fail when cancelling an already deleted buy order", async function () {
         const buyOrder1 = {
-            amount: global.web3v1.utils.toWei("1"),
+            amount: web3.utils.toWei("1"),
             maker: makers[0],
             price: 1020000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
         const buyOrder2 = {
-            amount: global.web3v1.utils.toWei("1"),
+            amount: web3.utils.toWei("1"),
             maker: makers[0],
             price: 1020000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
 
         await exchangeTestHelpers.newOrder(this, buyOrder1);
@@ -239,12 +239,12 @@ contract("Exchange orders tests", accounts => {
         await testHelpers.expectThrow(exchange.cancelBuyTokenOrder(buyOrder2.id));
     });
 
-    it("only own orders should be possible to cancel", async function() {
+    it("only own orders should be possible to cancel", async function () {
         const buyOrder = {
-            amount: global.web3v1.utils.toWei("1"),
+            amount: web3.utils.toWei("1"),
             maker: makers[0],
             price: 1020000,
-            orderType: TOKEN_BUY
+            orderType: TOKEN_BUY,
         };
         const sellOrder = { amount: 45454, maker: makers[0], price: 1010000, orderType: TOKEN_SELL };
 
@@ -254,50 +254,40 @@ contract("Exchange orders tests", accounts => {
         await testHelpers.expectThrow(exchange.cancelSellTokenOrder(sellOrder.id, { from: accounts[0] }));
     });
 
-    it("should return CHUNK_SIZE buy orders from offset", async function() {
+    it("should return CHUNK_SIZE buy orders from offset", async function () {
         const orderCount = 4;
         const orders = [];
         for (let i = 0; i < orderCount; i++) {
-            orders.push(
-                exchange.placeBuyTokenOrder(1000000 + i, { value: global.web3v1.utils.toWei("0.5"), from: makers[1] })
-            );
+            orders.push(exchange.placeBuyTokenOrder(1000000 + i, { value: web3.utils.toWei("0.5"), from: makers[1] }));
         }
         const txs = await Promise.all(orders);
         assert(txs.length, orderCount);
 
         const orderQueries = [
-            exchangeTestHelpers.getActiveBuyOrders(0, CHUNK_SIZE).then(res => {
-                assert.equal(
-                    res.length,
-                    Math.min(orderCount, CHUNK_SIZE),
-                    "buy orders count when 0 offset"
-                );
+            exchangeTestHelpers.getActiveBuyOrders(0, CHUNK_SIZE).then((res) => {
+                assert.equal(res.length, Math.min(orderCount, CHUNK_SIZE), "buy orders count when 0 offset");
             }),
-            exchangeTestHelpers.getActiveBuyOrders(1, CHUNK_SIZE).then(res => {
-                assert.equal(
-                    res.length,
-                    Math.min(orderCount - 1, CHUNK_SIZE),
-                    "buy count when offset from 1"
-                );
+            exchangeTestHelpers.getActiveBuyOrders(1, CHUNK_SIZE).then((res) => {
+                assert.equal(res.length, Math.min(orderCount - 1, CHUNK_SIZE), "buy count when offset from 1");
             }),
-            exchangeTestHelpers.getActiveBuyOrders(orderCount - 1, CHUNK_SIZE).then(res => {
+            exchangeTestHelpers.getActiveBuyOrders(orderCount - 1, CHUNK_SIZE).then((res) => {
                 assert.equal(res.length, 1, "returned buy orders count when offset from last");
             }),
-            exchangeTestHelpers.getActiveBuyOrders(orderCount, CHUNK_SIZE).then(res => {
+            exchangeTestHelpers.getActiveBuyOrders(orderCount, CHUNK_SIZE).then((res) => {
                 assert.equal(res.length, 0, "returned buy orders count when offset > last");
-            })
+            }),
         ];
 
         await Promise.all(orderQueries);
     });
 
-    it("should return CHUNK_SIZE sell orders from offset", async function() {
+    it("should return CHUNK_SIZE sell orders from offset", async function () {
         const orderCount = 4;
         const orders = [];
         for (let i = 0; i < orderCount; i++) {
             orders.push(
                 augmintToken.transferAndNotify(exchange.address, i + 1, 1000000 + i, {
-                    from: makers[0]
+                    from: makers[0],
                 })
             );
         }
@@ -305,32 +295,24 @@ contract("Exchange orders tests", accounts => {
         assert(txs.length, orderCount);
 
         const orderQueries = [
-            exchangeTestHelpers.getActiveSellOrders(0, CHUNK_SIZE).then(res => {
-                assert.equal(
-                    res.length,
-                    Math.min(orderCount, CHUNK_SIZE),
-                    "sell orders count when 0 offset"
-                );
+            exchangeTestHelpers.getActiveSellOrders(0, CHUNK_SIZE).then((res) => {
+                assert.equal(res.length, Math.min(orderCount, CHUNK_SIZE), "sell orders count when 0 offset");
             }),
-            exchangeTestHelpers.getActiveSellOrders(1, CHUNK_SIZE).then(res => {
-                assert.equal(
-                    res.length,
-                    Math.min(orderCount - 1, CHUNK_SIZE),
-                    "sell count when offset from 1"
-                );
+            exchangeTestHelpers.getActiveSellOrders(1, CHUNK_SIZE).then((res) => {
+                assert.equal(res.length, Math.min(orderCount - 1, CHUNK_SIZE), "sell count when offset from 1");
             }),
-            exchangeTestHelpers.getActiveSellOrders(orderCount - 1, CHUNK_SIZE).then(res => {
+            exchangeTestHelpers.getActiveSellOrders(orderCount - 1, CHUNK_SIZE).then((res) => {
                 assert.equal(res.length, 1, "returned sell orders count when offset from last");
             }),
-            exchangeTestHelpers.getActiveSellOrders(orderCount, CHUNK_SIZE).then(res => {
+            exchangeTestHelpers.getActiveSellOrders(orderCount, CHUNK_SIZE).then((res) => {
                 assert.equal(res.length, 0, "returned sell orders count when offset > last");
-            })
+            }),
         ];
 
         await Promise.all(orderQueries);
     });
 
-    it("should only allow the token contract call transferNotification", async function() {
+    it("should only allow the token contract call transferNotification", async function () {
         await testHelpers.expectThrow(exchange.transferNotification(accounts[0], 1000000, 0, { from: accounts[0] }));
     });
 });

--- a/test/feeAccount.js
+++ b/test/feeAccount.js
@@ -1,47 +1,49 @@
 const testHelpers = require("./helpers/testHelpers.js");
 const tokenTestHelpers = require("./helpers/tokenTestHelpers.js");
 
+const BN = web3.utils.BN;
+
 let feeAccountInstance;
 let augmintTokenInstance;
 
-contract("FeeAccount tests", accounts => {
+contract("FeeAccount tests", (accounts) => {
     before(async () => {
         feeAccountInstance = tokenTestHelpers.feeAccount;
         augmintTokenInstance = tokenTestHelpers.augmintToken;
     });
 
-    it("should be possible to set transfer fees ", async function() {
-        const fee = { pt: 100000, max: 80, min: 90 };
-        const tx = await feeAccountInstance.setTransferFees(fee.pt, fee.min, fee.max, { from: accounts[0] });
+    it("should be possible to set transfer fees ", async function () {
+        const newFee = { pt: 100000, max: 80, min: 90 };
+        const tx = await feeAccountInstance.setTransferFees(newFee.pt, newFee.min, newFee.max, { from: accounts[0] });
         testHelpers.logGasUse(this, tx, "setTransferFees");
 
-        const [feePt, feeMin, feeMax] = await feeAccountInstance.transferFee();
+        const actFee = await feeAccountInstance.transferFee();
 
         await testHelpers.assertEvent(feeAccountInstance, "TransferFeesChanged", {
-            transferFeePt: fee.pt,
-            transferFeeMin: fee.min,
-            transferFeeMax: fee.max
+            transferFeePt: newFee.pt.toString(),
+            transferFeeMin: newFee.min.toString(),
+            transferFeeMax: newFee.max.toString(),
         });
 
-        assert.equal(feePt, fee.pt);
-        assert.equal(feeMin, fee.min);
-        assert.equal(feeMax, fee.max);
+        assert.equal(actFee.pt, newFee.pt);
+        assert.equal(actFee.min, newFee.min);
+        assert.equal(actFee.max, newFee.max);
     });
 
-    it("only allowed should set transfer fees ", async function() {
+    it("only allowed should set transfer fees ", async function () {
         await testHelpers.expectThrow(feeAccountInstance.setTransferFees(10000, 10000, 10000, { from: accounts[1] }));
     });
 
-    it("should be possible to withdraw from fee account", async function() {
-        const weiAmount = global.web3v1.utils.toWei("0.2");
+    it("should be possible to withdraw from fee account", async function () {
+        const weiAmount = new BN(web3.utils.toWei("0.2"));
 
-        const tokenAmount = 10000;
+        const tokenAmount = new BN(10000);
         const narrative = "test withdrawal";
         // top up feeAccount with  ETH
-        await global.web3v1.eth.sendTransaction({
+        await web3.eth.sendTransaction({
             from: accounts[0],
             to: feeAccountInstance.address,
-            value: weiAmount
+            value: weiAmount,
         });
 
         // top up feeAccount with tokens
@@ -49,7 +51,7 @@ contract("FeeAccount tests", accounts => {
 
         const balBefore = await tokenTestHelpers.getAllBalances({
             to: accounts[0],
-            feeAccount: feeAccountInstance.address
+            feeAccount: feeAccountInstance.address,
         });
 
         const tx = await feeAccountInstance.withdraw(
@@ -61,32 +63,33 @@ contract("FeeAccount tests", accounts => {
         );
         testHelpers.logGasUse(this, tx, "withdraw");
 
+        console.log(" weiAmount", weiAmount, typeof weiAmount);
         await Promise.all([
             testHelpers.assertEvent(feeAccountInstance, "WithdrawFromSystemAccount", {
                 tokenAddress: augmintTokenInstance.address,
                 to: accounts[0],
-                tokenAmount,
-                weiAmount,
-                narrative
+                tokenAmount: tokenAmount.toString(),
+                weiAmount: weiAmount.toString(),
+                narrative,
             }),
             tokenTestHelpers.assertBalances(balBefore, {
                 to: {
                     eth: balBefore.to.eth.add(weiAmount),
                     ace: balBefore.to.ace.add(tokenAmount),
-                    gasFee: testHelpers.GAS_PRICE * 70000
+                    gasFee: testHelpers.GAS_PRICE * 70000,
                 },
                 feeAccount: {
                     eth: balBefore.feeAccount.eth.sub(weiAmount),
-                    ace: balBefore.feeAccount.ace.sub(tokenAmount)
-                }
-            })
+                    ace: balBefore.feeAccount.ace.sub(tokenAmount),
+                },
+            }),
         ]);
     });
 
-    it("only allowed should withdraw from fee account", async function() {
+    it("only allowed should withdraw from fee account", async function () {
         await testHelpers.expectThrow(
             feeAccountInstance.withdraw(augmintTokenInstance.address, accounts[0], 0, 0, "should fail", {
-                from: accounts[1]
+                from: accounts[1],
             })
         );
     });

--- a/test/helpers/exchangeTestHelpers.js
+++ b/test/helpers/exchangeTestHelpers.js
@@ -1,5 +1,3 @@
-const BigNumber = require("bignumber.js");
-
 const Exchange = artifacts.require("./Exchange.sol");
 const Rates = artifacts.require("./Rates.sol");
 const testHelpers = new require("./testHelpers.js");
@@ -9,7 +7,7 @@ const PLACE_ORDER_MAX_GAS = 200000;
 const CANCEL_SELL_MAX_GAS = 150000;
 const MATCH_ORDER_MAX_GAS = 110000;
 
-const PPM_DIV = 1000000;
+const BN = web3.utils.BN;
 
 module.exports = {
     newOrder,
@@ -23,23 +21,22 @@ module.exports = {
     printOrderBook,
     get exchange() {
         return exchange;
-    }
+    },
 };
 
 let exchange = null;
 let augmintToken = null;
 let rates;
 
-before(async function() {
+before(async function () {
     augmintToken = tokenTestHelpers.augmintToken;
-    exchange = Exchange.at(Exchange.address);
-    rates = Rates.at(Rates.address);
+    [exchange, rates] = await Promise.all([Exchange.at(Exchange.address), Rates.at(Rates.address)]);
 });
 
 async function newOrder(testInstance, order) {
     const stateBefore = await getState();
     const balBefore = await tokenTestHelpers.getAllBalances({ exchange: exchange.address, maker: order.maker });
-    order.amount = new BigNumber(order.amount); // to handle numbers, strings and BigNumbers passed
+    order.amount = new BN(order.amount); // to handle numbers, strings and BNs passed
     order.viaAugmintToken =
         typeof order.viaAugmintToken === "undefined" && order.orderType === testHelpers.TOKEN_SELL
             ? true
@@ -48,21 +45,21 @@ async function newOrder(testInstance, order) {
     if (order.orderType === testHelpers.TOKEN_BUY) {
         tx = await exchange.placeBuyTokenOrder(order.price, {
             value: order.amount,
-            from: order.maker
+            from: order.maker,
         });
         testHelpers.logGasUse(testInstance, tx, "placeBuyTokenOrder");
-        order.tokenAmount = 0;
+        order.tokenAmount = new BN(0);
         order.weiAmount = order.amount;
     } else {
         if (order.viaAugmintToken) {
             tx = await augmintToken.transferAndNotify(exchange.address, order.amount, order.price, {
-                from: order.maker
+                from: order.maker,
             });
             testHelpers.logGasUse(testInstance, tx, "transferAndNotify - token sell");
         } else {
             const approvedBefore = await augmintToken.allowed(order.maker, exchange.address);
             tx = await exchange.placeSellTokenOrder(order.price, order.amount, {
-                from: order.maker
+                from: order.maker,
             });
             testHelpers.logGasUse(testInstance, tx, "placeSellTokenOrder");
             const approvedAfter = await augmintToken.allowed(order.maker, exchange.address);
@@ -74,12 +71,11 @@ async function newOrder(testInstance, order) {
         }
 
         order.tokenAmount = order.amount;
-        order.weiAmount = 0;
+        order.weiAmount = new BN(0);
     }
 
     const eventResult = await newOrderEventAsserts(order);
     order.id = parseInt(eventResult.orderId);
-
     const state = await getState();
 
     let actualOrder, expBuyCount, expSellCount;
@@ -107,37 +103,37 @@ async function newOrder(testInstance, order) {
     await tokenTestHelpers.assertBalances(balBefore, {
         exchange: {
             eth: balBefore.exchange.eth.add(order.weiAmount),
-            ace: balBefore.exchange.ace.add(order.tokenAmount)
+            ace: balBefore.exchange.ace.add(order.tokenAmount),
         },
         maker: {
             eth: balBefore.maker.eth.sub(order.weiAmount),
             ace: balBefore.maker.ace.sub(order.tokenAmount),
-            gasFee: PLACE_ORDER_MAX_GAS * testHelpers.GAS_PRICE
-        }
+            gasFee: PLACE_ORDER_MAX_GAS * testHelpers.GAS_PRICE,
+        },
     });
 }
 
 async function newOrderEventAsserts(order) {
     const res = await testHelpers.assertEvent(exchange, "NewOrder", {
-        orderId: x => x,
+        orderId: (x) => x,
         maker: order.maker,
-        price: order.price,
+        price: order.price.toString(),
         weiAmount: order.weiAmount.toString(),
-        tokenAmount: order.tokenAmount.toString()
+        tokenAmount: order.tokenAmount.toString(),
     });
 
     if (order.orderType === testHelpers.TOKEN_SELL) {
         await testHelpers.assertEvent(augmintToken, "Transfer", {
             from: order.maker,
             to: exchange.address,
-            amount: order.tokenAmount.toString()
+            amount: order.tokenAmount.toString(),
         });
         await testHelpers.assertEvent(augmintToken, "AugmintTransfer", {
             from: order.maker,
             to: exchange.address,
             amount: order.tokenAmount.toString(),
-            fee: 0,
-            narrative: ""
+            fee: "0",
+            narrative: "",
         });
     }
     return res;
@@ -159,17 +155,17 @@ async function cancelOrder(testInstance, order) {
 
     if (sell) {
         order.tokenAmount = order.amount;
-        order.weiAmount = 0;
+        order.weiAmount = new BN(0);
     } else {
-        order.tokenAmount = 0;
+        order.tokenAmount = new BN(0);
         order.weiAmount = order.amount;
     }
 
     await testHelpers.assertEvent(exchange, "CancelledOrder", {
-        orderId: order.id,
+        orderId: order.id.toString(),
         maker: order.maker,
         tokenAmount: order.tokenAmount.toString(),
-        weiAmount: order.weiAmount.toString()
+        weiAmount: order.weiAmount.toString(),
     });
 
     let expSellCount, expBuyCount;
@@ -178,8 +174,8 @@ async function cancelOrder(testInstance, order) {
             amount: order.amount.toString(),
             from: exchange.address,
             to: order.maker,
-            fee: 0,
-            narrative: "Sell token order cancelled"
+            fee: "0",
+            narrative: "Sell token order cancelled",
         });
         expSellCount = stateBefore.sellCount - 1;
         expBuyCount = stateBefore.buyCount;
@@ -194,13 +190,13 @@ async function cancelOrder(testInstance, order) {
     await tokenTestHelpers.assertBalances(balBefore, {
         exchange: {
             eth: balBefore.exchange.eth.sub(order.weiAmount),
-            ace: balBefore.exchange.ace.sub(order.tokenAmount)
+            ace: balBefore.exchange.ace.sub(order.tokenAmount),
         },
         maker: {
             eth: balBefore.maker.eth.add(order.weiAmount),
             ace: balBefore.maker.ace.add(order.tokenAmount),
-            gasFee: CANCEL_SELL_MAX_GAS * testHelpers.GAS_PRICE
-        }
+            gasFee: CANCEL_SELL_MAX_GAS * testHelpers.GAS_PRICE,
+        },
     });
 
     return;
@@ -212,25 +208,26 @@ async function matchOrders(testInstance, buyTokenOrder, sellTokenOrder) {
     const balancesBefore = await tokenTestHelpers.getAllBalances({
         exchange: exchange.address,
         seller: sellTokenOrder.maker,
-        buyer: buyTokenOrder.maker
+        buyer: buyTokenOrder.maker,
     });
 
     const matchCaller = global.accounts[0];
-    const currentRate = parseInt((await rates.rates("EUR"))[0]);
+    const currentRate = new BN((await rates.rates(web3.utils.asciiToHex("EUR")))[0]);
 
-    const expPrice = buyTokenOrder.id > sellTokenOrder.id ? sellTokenOrder.price : buyTokenOrder.price;
+    const expPrice = new BN(buyTokenOrder.id > sellTokenOrder.id ? sellTokenOrder.price : buyTokenOrder.price);
 
     const sellWeiValue = sellTokenOrder.amount
-        .mul(testHelpers.ONE_ETH)
+        .mul(new BN(testHelpers.BN_ONE_ETH))
         .mul(expPrice)
         .div(currentRate)
-        .div(PPM_DIV)
-        .round(0, BigNumber.ROUND_HALF_UP);
-    const buyTokenValue =
-        Math.round(buyTokenOrder.amount * currentRate * PPM_DIV / expPrice / testHelpers.ONE_ETH);
+        .divRound(testHelpers.PPM_DIV);
 
-    const tradedWeiAmount = BigNumber.min(buyTokenOrder.amount, sellWeiValue);
-    const tradedTokenAmount = BigNumber.min(sellTokenOrder.amount, buyTokenValue);
+    const buyTokenValue = Math.round(
+        (buyTokenOrder.amount * currentRate * testHelpers.PPM_DIV) / expPrice / testHelpers.ONE_ETH
+    );
+
+    const tradedWeiAmount = BN.min(new BN(buyTokenOrder.amount), sellWeiValue);
+    const tradedTokenAmount = BN.min(new BN(sellTokenOrder.amount), new BN(buyTokenValue));
     const buyFilled = buyTokenOrder.amount.eq(tradedWeiAmount);
     const sellFilled = sellTokenOrder.amount.eq(tradedTokenAmount);
 
@@ -241,38 +238,38 @@ async function matchOrders(testInstance, buyTokenOrder, sellTokenOrder) {
         tokenBuyer: buyTokenOrder.maker,
         price: expPrice,
         weiAmount: tradedWeiAmount,
-        tokenAmount: tradedTokenAmount,
+        tokenAmount: new BN(tradedTokenAmount),
         buyFilled: buyFilled,
         sellFilled: sellFilled,
         sellCount: sellFilled ? stateBefore.sellCount - 1 : stateBefore.sellCount,
-        buyCount: buyFilled ? stateBefore.buyCount - 1 : stateBefore.buyCount
+        buyCount: buyFilled ? stateBefore.buyCount - 1 : stateBefore.buyCount,
     };
 
     const tx = await exchange.matchOrders(buyTokenOrder.id, sellTokenOrder.id);
     testHelpers.logGasUse(testInstance, tx, "matchOrders");
 
     await testHelpers.assertEvent(exchange, "OrderFill", {
-        sellTokenOrderId: expMatch.sellTokenOrderId,
-        buyTokenOrderId: expMatch.buyTokenOrderId,
+        sellTokenOrderId: expMatch.sellTokenOrderId.toString(),
+        buyTokenOrderId: expMatch.buyTokenOrderId.toString(),
         tokenSeller: expMatch.tokenSeller,
         tokenBuyer: expMatch.tokenBuyer,
-        publishedRate: currentRate,
-        price: expMatch.price,
+        publishedRate: currentRate.toString(),
+        price: expMatch.price.toString(),
         weiAmount: expMatch.weiAmount.toString(),
-        tokenAmount: expMatch.tokenAmount.toString()
+        tokenAmount: expMatch.tokenAmount.toString(),
     });
 
     await testHelpers.assertEvent(augmintToken, "Transfer", {
         from: exchange.address,
         to: expMatch.tokenBuyer,
-        amount: expMatch.tokenAmount.toString()
+        amount: expMatch.tokenAmount.toString(),
     });
     await testHelpers.assertEvent(augmintToken, "AugmintTransfer", {
         from: exchange.address,
         to: expMatch.tokenBuyer,
         amount: expMatch.tokenAmount.toString(),
-        fee: 0,
-        narrative: "Buy token order fill"
+        fee: "0",
+        narrative: "Buy token order fill",
     });
 
     const stateAfter = await getState();
@@ -282,29 +279,30 @@ async function matchOrders(testInstance, buyTokenOrder, sellTokenOrder) {
     await tokenTestHelpers.assertBalances(balancesBefore, {
         exchange: {
             eth: balancesBefore.exchange.eth.sub(expMatch.weiAmount),
-            ace: balancesBefore.exchange.ace.sub(expMatch.tokenAmount)
-        }
+            ace: balancesBefore.exchange.ace.sub(expMatch.tokenAmount),
+        },
     });
+
     if (balancesBefore.seller.address === balancesBefore.buyer.address) {
         await tokenTestHelpers.assertBalances(balancesBefore, {
             seller: {
                 eth: balancesBefore.seller.eth.add(expMatch.weiAmount),
                 ace: balancesBefore.seller.ace.add(expMatch.tokenAmount),
-                gasFee: matchCaller === sellTokenOrder.maker ? MATCH_ORDER_MAX_GAS * testHelpers.GAS_PRICE : 0
-            }
+                gasFee: matchCaller === sellTokenOrder.maker ? MATCH_ORDER_MAX_GAS * testHelpers.GAS_PRICE : 0,
+            },
         });
     } else {
         await tokenTestHelpers.assertBalances(balancesBefore, {
             seller: {
                 eth: balancesBefore.seller.eth.add(expMatch.weiAmount),
                 ace: balancesBefore.seller.ace,
-                gasFee: matchCaller === sellTokenOrder.maker ? MATCH_ORDER_MAX_GAS * testHelpers.GAS_PRICE : 0
+                gasFee: matchCaller === sellTokenOrder.maker ? MATCH_ORDER_MAX_GAS * testHelpers.GAS_PRICE : 0,
             },
             buyer: {
                 eth: balancesBefore.buyer.eth,
                 ace: balancesBefore.buyer.ace.add(expMatch.tokenAmount),
-                gasFee: matchCaller === buyTokenOrder.maker ? MATCH_ORDER_MAX_GAS * testHelpers.GAS_PRICE : 0
-            }
+                gasFee: matchCaller === buyTokenOrder.maker ? MATCH_ORDER_MAX_GAS * testHelpers.GAS_PRICE : 0,
+            },
         });
     }
 
@@ -321,7 +319,7 @@ async function getState() {
 
 async function getBuyTokenOrder(id) {
     const order = parseOrder(await exchange.buyTokenOrders(id));
-    order.id = id;  // ID is not filled if we got the order directly from buyTokenOrders
+    order.id = id; // ID is not filled if we got the order directly from buyTokenOrders
     order.weiAmount = order.amount;
     order.tokenAmount = 0;
     order.orderType = testHelpers.TOKEN_BUY;
@@ -330,7 +328,7 @@ async function getBuyTokenOrder(id) {
 
 async function getSellTokenOrder(id) {
     const order = parseOrder(await exchange.sellTokenOrders(id));
-    order.id = id;  // ID is not filled if we got the order directly from sellTokenOrders
+    order.id = id; // ID is not filled if we got the order directly from sellTokenOrders
     order.weiAmount = 0;
     order.tokenAmount = order.amount;
     order.orderType = testHelpers.TOKEN_SELL;
@@ -345,20 +343,20 @@ function parseOrder(order) {
     return {
         maker: order[1],
         price: order[2].toNumber(),
-        amount: order[3]
+        amount: order[3],
     };
 }
 
 // Parse an order coming from getActiveBuyOrders/getActiveSellOrders
 // has id, maker is in number format, no index at all (order[0] already contains the id)
 function parseOrders(orderType, orders) {
-    return orders.map(function(order) {
+    return orders.map(function (order) {
         return {
             orderType: orderType,
             id: order[0].toNumber(),
-            maker: "0x" + order[1].toString(16).padStart(40, "0"), // leading 0s if address starts with 0
+            maker: web3.utils.toChecksumAddress("0x" + order[1].toString(16).padStart(40, "0")), // leading 0s if address starts with 0
             price: order[2].toNumber(),
-            amount: order[3]
+            amount: order[3],
         };
     });
 }
@@ -394,8 +392,9 @@ async function printOrderBook(_limit) {
     });
     buyOrders.slice(0, _limit).map((order, i) => {
         console.log(
-            `        ${i}. BUY token: price: ${order.price / 10000}% amount: ${order.amount /
-                testHelpers.ONE_ETH} ETH` + `  orderId: ${order.id} acc: ${order.maker}`
+            `        ${i}. BUY token: price: ${order.price / 10000}% amount: ${
+                order.amount / testHelpers.ONE_ETH
+            } ETH` + `  orderId: ${order.id} acc: ${order.maker}`
         );
     });
 

--- a/test/helpers/loanTestHelpers.js
+++ b/test/helpers/loanTestHelpers.js
@@ -1,4 +1,3 @@
-const BigNumber = require("bignumber.js");
 const moment = require("moment");
 
 const LoanManager = artifacts.require("./LoanManager.sol");
@@ -7,8 +6,10 @@ const Rates = artifacts.require("./Rates.sol");
 const tokenTestHelpers = require("./tokenTestHelpers.js");
 const testHelpers = require("./testHelpers.js");
 
+const BN = web3.utils.BN;
+
 const NEWLOAN_MAX_GAS = 220000;
-const REPAY_MAX_GAS = 140000;
+const REPAY_MAX_GAS = 150000;
 const COLLECT_BASE_GAS = 110000;
 
 let augmintToken = null;
@@ -29,19 +30,20 @@ module.exports = {
     loanAsserts,
     get loanManager() {
         return loanManager;
-    }
+    },
 };
 
-before(async function() {
-    loanManager = LoanManager.at(LoanManager.address);
-    augmintToken = tokenTestHelpers.augmintToken;
-    monetarySupervisor = tokenTestHelpers.monetarySupervisor;
+before(async function () {
+    [loanManager, augmintToken, monetarySupervisor, rates] = await Promise.all([
+        LoanManager.at(LoanManager.address),
+        tokenTestHelpers.augmintToken,
+        tokenTestHelpers.monetarySupervisor,
+        Rates.at(Rates.address),
+    ]);
 
     reserveAcc = tokenTestHelpers.augmintReserves.address;
     interestEarnedAcc = tokenTestHelpers.interestEarnedAccount.address;
     peggedSymbol = tokenTestHelpers.peggedSymbol;
-
-    rates = Rates.at(Rates.address);
 });
 
 async function createLoan(testInstance, product, borrower, collateralWei, minRate = 0) {
@@ -56,35 +58,35 @@ async function createLoan(testInstance, product, borrower, collateralWei, minRat
             reserve: reserveAcc,
             borrower: loan.borrower,
             loanManager: loanManager.address,
-            interestEarned: interestEarnedAcc
-        })
+            interestEarned: interestEarnedAcc,
+        }),
     ]);
 
     const tx = await loanManager.newEthBackedLoan(loan.product.id, minRate, {
         from: loan.borrower,
-        value: loan.collateralAmount
+        value: loan.collateralAmount,
     });
     testHelpers.logGasUse(testInstance, tx, "newEthBackedLoan");
 
-    const [newLoanEvenResult, ,] = await Promise.all([
+    const [newLoanEventResult, ,] = await Promise.all([
         testHelpers.assertEvent(loanManager, "NewLoan", {
-            loanId: x => x,
-            productId: loan.product.id.toNumber(),
+            loanId: (x) => x,
+            productId: loan.product.id.toString(),
             borrower: loan.borrower,
             collateralAmount: loan.collateralAmount.toString(),
             loanAmount: loan.loanAmount.toString(),
             repaymentAmount: loan.repaymentAmount.toString(),
-            maturity: x => x,
-            currentRate: x => x
+            maturity: (x) => x,
+            currentRate: (x) => x,
         }),
 
         testHelpers.assertEvent(augmintToken, "AugmintTransfer", {
             from: testHelpers.NULL_ACC,
             to: loan.borrower,
             amount: loan.loanAmount.toString(),
-            fee: 0,
-            narrative: ""
-        })
+            fee: "0",
+            narrative: "",
+        }),
 
         // TODO: it's emmited  but why  not picked up by assertEvent?
         // testHelpers.assertEvent(augmintToken, "Transfer", {
@@ -94,9 +96,9 @@ async function createLoan(testInstance, product, borrower, collateralWei, minRat
         // })
     ]);
 
-    loan.id = newLoanEvenResult.loanId.toNumber();
-    loan.maturity = newLoanEvenResult.maturity.toNumber();
-    loan.currentRate = newLoanEvenResult.currentRate.toNumber();
+    loan.id = parseInt(newLoanEventResult.loanId);
+    loan.maturity = parseInt(newLoanEventResult.maturity);
+    loan.currentRate = parseInt(newLoanEventResult.currentRate);
 
     const [totalSupplyAfter, totalLoanAmountAfter, ,] = await Promise.all([
         augmintToken.totalSupply(),
@@ -108,14 +110,14 @@ async function createLoan(testInstance, product, borrower, collateralWei, minRat
             reserve: {},
             borrower: {
                 ace: balBefore.borrower.ace.add(loan.loanAmount),
-                eth: balBefore.borrower.eth.minus(loan.collateralAmount),
-                gasFee: NEWLOAN_MAX_GAS * testHelpers.GAS_PRICE
+                eth: balBefore.borrower.eth.sub(loan.collateralAmount),
+                gasFee: NEWLOAN_MAX_GAS * testHelpers.GAS_PRICE,
             },
             loanManager: {
-                eth: balBefore.loanManager.eth.plus(loan.collateralAmount)
+                eth: balBefore.loanManager.eth.add(loan.collateralAmount),
             },
-            interestEarned: {}
-        })
+            interestEarned: {},
+        }),
     ]);
 
     assert.equal(
@@ -139,13 +141,13 @@ async function repayLoan(testInstance, loan) {
             reserve: reserveAcc,
             borrower: loan.borrower,
             loanManager: loanManager.address,
-            interestEarned: interestEarnedAcc
-        })
+            interestEarned: interestEarnedAcc,
+        }),
     ]);
 
     loan.state = 1; // repaid
     const tx = await augmintToken.transferAndNotify(loanManager.address, loan.repaymentAmount, loan.id, {
-        from: loan.borrower
+        from: loan.borrower,
     });
     testHelpers.logGasUse(testInstance, tx, "transferAndNotify - repayLoan");
 
@@ -154,9 +156,9 @@ async function repayLoan(testInstance, loan) {
         monetarySupervisor.totalLoanAmount(),
 
         testHelpers.assertEvent(loanManager, "LoanRepaid", {
-            loanId: loan.id,
+            loanId: loan.id.toString(),
             borrower: loan.borrower,
-            currentRate: x => x
+            currentRate: (x) => x,
         }),
 
         /* TODO: these are emmited  but why not picked up by assertEvent? */
@@ -180,23 +182,20 @@ async function repayLoan(testInstance, loan) {
             borrower: {
                 ace: balBefore.borrower.ace.sub(loan.repaymentAmount),
                 eth: balBefore.borrower.eth.add(loan.collateralAmount),
-                gasFee: REPAY_MAX_GAS * testHelpers.GAS_PRICE
+                gasFee: REPAY_MAX_GAS * testHelpers.GAS_PRICE,
             },
             loanManager: {
-                eth: balBefore.loanManager.eth.minus(loan.collateralAmount)
+                eth: balBefore.loanManager.eth.sub(loan.collateralAmount),
             },
             interestEarned: {
-                ace: balBefore.interestEarned.ace.add(loan.interestAmount)
-            }
-        })
+                ace: balBefore.interestEarned.ace.add(loan.interestAmount),
+            },
+        }),
     ]);
 
     assert.equal(
         totalSupplyAfter.toString(),
-        totalSupplyBefore
-            .sub(loan.repaymentAmount)
-            .add(loan.interestAmount)
-            .toString(),
+        totalSupplyBefore.sub(loan.repaymentAmount).add(loan.interestAmount).toString(),
         "total supply should be reduced by the repayment amount less interestAmount"
     );
     assert.equal(
@@ -210,18 +209,17 @@ async function collectLoan(testInstance, loan, collector) {
     loan.collector = collector;
     loan.state = 3; // Collected
 
-    const targetCollectionInToken = loan.repaymentAmount.mul(loan.product.defaultingFeePt.add(1000000)).div(1000000);
-    const targetFeeInToken = loan.repaymentAmount.mul(loan.product.defaultingFeePt).div(1000000);
-    //.round(0, BigNumber.ROUND_DOWN);
+    const targetCollectionInToken = loan.repaymentAmount
+        .mul(loan.product.defaultingFeePt.add(testHelpers.PPM_DIV))
+        .div(testHelpers.PPM_DIV);
+    const targetFeeInToken = loan.repaymentAmount.mul(loan.product.defaultingFeePt).div(testHelpers.PPM_DIV);
 
     const [
         totalSupplyBefore,
         totalLoanAmountBefore,
         balBefore,
-        collateralInToken,
-        repaymentAmountInWei,
         targetCollectionInWei,
-        targetFeeInWei
+        targetFeeInWei,
     ] = await Promise.all([
         augmintToken.totalSupply(),
         monetarySupervisor.totalLoanAmount(),
@@ -232,32 +230,16 @@ async function collectLoan(testInstance, loan, collector) {
             borrower: loan.borrower,
             loanManager: loanManager.address,
             interestEarned: interestEarnedAcc,
-            feeAccount: tokenTestHelpers.feeAccount
+            feeAccount: tokenTestHelpers.feeAccount,
         }),
-        rates.convertFromWei(peggedSymbol, loan.collateralAmount),
-        rates.convertToWei(peggedSymbol, loan.repaymentAmount),
+
         rates.convertToWei(peggedSymbol, targetCollectionInToken),
-        rates.convertToWei(peggedSymbol, targetFeeInToken)
+        rates.convertToWei(peggedSymbol, targetFeeInToken),
     ]);
 
-    const releasedCollateral = BigNumber.max(loan.collateralAmount.sub(targetCollectionInWei), 0);
+    const releasedCollateral = BN.max(loan.collateralAmount.sub(targetCollectionInWei), new BN(0));
     const collectedCollateral = loan.collateralAmount.sub(releasedCollateral);
-    const defaultingFee = BigNumber.min(targetFeeInWei, collectedCollateral);
-
-    // const rate = await rates.rates("EUR");
-    // console.log(
-    //     `    *** Collection params:
-    //      A-EUR/EUR: ${rate[0] / 100}
-    //      defaulting fee pt: ${loan.product.defaultingFeePt / 10000} %
-    //      repaymentAmount: ${loan.repaymentAmount / 10000} A-EUR = ${repaymentAmountInWei / testHelpers.ONE_ETH} ETH
-    //      collateral: ${loan.collateralAmount / testHelpers.ONE_ETH} ETH = ${collateralInToken / 100} A-EUR
-    //      --------------------
-    //      targetFee: ${targetFeeInToken / 100} A-EUR = ${targetFeeInWei / testHelpers.ONE_ETH} ETH
-    //      target collection : ${targetCollectionInToken / 100} A-EUR = ${targetCollectionInWei / testHelpers.ONE_ETH} ETH
-    //      collected: ${collectedCollateral / testHelpers.ONE_ETH} ETH
-    //      released: ${releasedCollateral / testHelpers.ONE_ETH} ETH
-    //      defaultingFee: ${defaultingFee / testHelpers.ONE_ETH} ETH`
-    // );
+    const defaultingFee = BN.min(targetFeeInWei, collectedCollateral);
 
     const tx = await loanManager.collect([loan.id], { from: loan.collector });
 
@@ -268,39 +250,39 @@ async function collectLoan(testInstance, loan, collector) {
         monetarySupervisor.totalLoanAmount(),
 
         testHelpers.assertEvent(loanManager, "LoanCollected", {
-            loanId: loan.id,
+            loanId: loan.id.toString(),
             borrower: loan.borrower,
             collectedCollateral: collectedCollateral.toString(),
             releasedCollateral: releasedCollateral.toString(),
             defaultingFee: defaultingFee.toString(),
-            currentRate: x => x
+            currentRate: (x) => x,
         }),
 
         loanAsserts(loan),
 
         tokenTestHelpers.assertBalances(balBefore, {
             reserve: {
-                eth: balBefore.reserve.eth.add(collectedCollateral).sub(defaultingFee)
+                eth: balBefore.reserve.eth.add(collectedCollateral).sub(defaultingFee),
             },
 
             feeAccount: {
-                eth: balBefore.feeAccount.eth.add(defaultingFee)
+                eth: balBefore.feeAccount.eth.add(defaultingFee),
             },
 
             collector: {
-                gasFee: COLLECT_BASE_GAS * testHelpers.GAS_PRICE
+                gasFee: COLLECT_BASE_GAS * testHelpers.GAS_PRICE,
             },
 
             borrower: {
-                eth: balBefore.borrower.eth.add(releasedCollateral)
+                eth: balBefore.borrower.eth.add(releasedCollateral),
             },
 
             loanManager: {
-                eth: balBefore.loanManager.eth.minus(loan.collateralAmount)
+                eth: balBefore.loanManager.eth.sub(loan.collateralAmount),
             },
 
-            interestEarned: {}
-        })
+            interestEarned: {},
+        }),
     ]);
 
     assert.equal(totalSupplyAfter.toString(), totalSupplyBefore.toString(), "totalSupply should be the same");
@@ -315,7 +297,7 @@ async function getProductsInfo(offset, chunkSize) {
     const products = await loanManager.getProducts(offset, chunkSize);
     assert(products.length <= chunkSize);
     const result = [];
-    products.map(prod => {
+    products.map((prod) => {
         const [
             id,
             minDisbursedAmount,
@@ -325,7 +307,7 @@ async function getProductsInfo(offset, chunkSize) {
             defaultingFeePt,
             maxLoanAmount,
             isActive,
-            minCollateralRatio
+            minCollateralRatio,
         ] = prod;
         assert(term.gt(0));
         result.push({
@@ -337,7 +319,7 @@ async function getProductsInfo(offset, chunkSize) {
             defaultingFeePt,
             maxLoanAmount,
             isActive,
-            minCollateralRatio
+            minCollateralRatio,
         });
     });
     return result;
@@ -346,7 +328,7 @@ async function getProductsInfo(offset, chunkSize) {
 /* parse array returned by getLoans & getLoansForAddress */
 function parseLoansInfo(loans) {
     const result = [];
-    loans.map(loan => {
+    loans.map((loan) => {
         const [
             id,
             collateralAmount,
@@ -359,7 +341,7 @@ function parseLoansInfo(loans) {
             loanAmount,
             interestAmount,
             marginCallRate,
-            isCollectable
+            isCollectable,
         ] = loan;
 
         assert(maturity.gt(0));
@@ -375,7 +357,7 @@ function parseLoansInfo(loans) {
             loanAmount,
             interestAmount,
             marginCallRate,
-            isCollectable
+            isCollectable,
         });
     });
     return result;
@@ -383,28 +365,23 @@ function parseLoansInfo(loans) {
 
 async function calcLoanValues(rates, product, collateralWei) {
     const ret = {};
-    const ppmDiv = 1000000;
 
-    ret.collateralAmount = new BigNumber(collateralWei);
+    ret.collateralAmount = new BN(collateralWei);
     ret.tokenValue = await rates.convertFromWei(peggedSymbol, collateralWei);
 
-    ret.repaymentAmount = ret.tokenValue
-        .mul(ppmDiv)
-        .div(product.initialCollateralRatio)
-        .round(0, BigNumber.ROUND_DOWN);
+    // in contract: uint repaymentAmount = collateralValueInToken.mul(PPM_FACTOR).div(product.initialCollateralRatio);
+    ret.repaymentAmount = ret.tokenValue.mul(testHelpers.PPM_DIV).div(product.initialCollateralRatio);
 
-    ret.loanAmount = ret.repaymentAmount
-        .mul(product.discountRate)
-        .div(ppmDiv)
-        .round(0, BigNumber.ROUND_UP);
+    //  in contract: loanAmount = repaymentAmount.mul(product.discountRate).ceilDiv(PPM_FACTOR);
+    ret.loanAmount = ret.repaymentAmount.mul(product.discountRate).div(testHelpers.PPM_DIV);
+    if (ret.repaymentAmount.mul(product.discountRate).mod(testHelpers.PPM_DIV).gt(new BN(0))) {
+        // no ceilDiv in BN
+        ret.loanAmount.iadd(new BN(1));
+    }
 
-    ret.interestAmount = ret.repaymentAmount.gt(ret.loanAmount)
-        ? ret.repaymentAmount.minus(ret.loanAmount)
-        : new BigNumber(0);
+    ret.interestAmount = ret.repaymentAmount.gt(ret.loanAmount) ? ret.repaymentAmount.sub(ret.loanAmount) : new BN(0);
 
-    ret.disbursementTime = moment()
-        .utc()
-        .unix();
+    ret.disbursementTime = moment().utc().unix();
     ret.product = product;
 
     return ret;
@@ -420,7 +397,7 @@ async function loanAsserts(expLoan) {
     assert.equal(loan[5].toNumber(), expLoan.maturity, "maturity should be the same as in NewLoan event");
 
     const maturityActual = loan[5];
-    const maturityExpected = expLoan.product.term.add(expLoan.disbursementTime).toNumber();
+    const maturityExpected = expLoan.product.term.toNumber() + expLoan.disbursementTime;
 
     assert(maturityActual >= maturityExpected, "maturity should be at least term + the time at disbursement");
     assert(

--- a/test/loanCollection.js
+++ b/test/loanCollection.js
@@ -9,11 +9,13 @@ let rates = null;
 const ltdParams = { lockDifferenceLimit: 300000, loanDifferenceLimit: 200000, allowedDifferenceAmount: 100000 };
 let products = {};
 
+const EUR = web3.utils.asciiToHex("EUR");
+
 let snapshotIdSingleTest;
 let snapshotIdAllTests;
 
-contract("Loans collection tests", accounts => {
-    before(async function() {
+contract("Loans collection tests", (accounts) => {
+    before(async function () {
         snapshotIdAllTests = await testHelpers.takeSnapshot();
 
         rates = ratesTestHelpers.rates;
@@ -21,12 +23,12 @@ contract("Loans collection tests", accounts => {
         loanManager = loanTestHelpers.loanManager;
 
         const [prodCount] = await Promise.all([
-            loanManager.getProductCount().then(res => res.toNumber()),
+            loanManager.getProductCount().then((res) => res.toNumber()),
             monetarySupervisor.setLtdParams(
                 ltdParams.lockDifferenceLimit,
                 ltdParams.loanDifferenceLimit,
                 ltdParams.allowedDifferenceAmount
-            )
+            ),
         ]);
         // These neeed to be sequential b/c product order assumed when retrieving via getProducts
         // term (in sec), discountRate, initialCollateralRatio, minDisbursedAmount (w/ 2 decimals), defaultingFeePt, isActive, minCollateralRatio
@@ -41,7 +43,7 @@ contract("Loans collection tests", accounts => {
 
         const [newProducts] = await Promise.all([
             loanTestHelpers.getProductsInfo(prodCount, 10),
-            tokenTestHelpers.issueToken(accounts[0], accounts[0], 1000000000)
+            tokenTestHelpers.issueToken(accounts[0], accounts[0], 1000000000),
         ]);
         [
             products.notDue,
@@ -51,7 +53,7 @@ contract("Loans collection tests", accounts => {
             products.negativeInterest,
             products.fullCoverage,
             products.moreCoverage,
-            products.margin
+            products.margin,
         ] = newProducts;
     });
 
@@ -59,128 +61,123 @@ contract("Loans collection tests", accounts => {
         await testHelpers.revertSnapshot(snapshotIdAllTests);
     });
 
-    beforeEach(async function() {
+    beforeEach(async function () {
         snapshotIdSingleTest = await testHelpers.takeSnapshot();
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
         await testHelpers.revertSnapshot(snapshotIdSingleTest);
     });
 
-    it("Should collect a defaulted A-EUR loan and send back leftover collateral ", async function() {
-        const loan = await loanTestHelpers.createLoan(
-            this,
-            products.defaulting,
-            accounts[1],
-            global.web3v1.utils.toWei("0.05")
-        );
+    it("Should collect a defaulted A-EUR loan and send back leftover collateral ", async function () {
+        const loan = await loanTestHelpers.createLoan(this, products.defaulting, accounts[1], web3.utils.toWei("0.05"));
 
         await testHelpers.waitForTimeStamp(loan.maturity);
 
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
 
-    it("Should collect a defaulted A-EUR loan when no leftover collateral (collection exactly covered)", async function() {
-        await rates.setRate("EUR", 100000);
+    it("Should collect a defaulted A-EUR loan when no leftover collateral (collection exactly covered)", async function () {
+        await rates.setRate(EUR, 100000);
         const loan = await loanTestHelpers.createLoan(
             this,
             products.defaultingNoLeftOver,
             accounts[1],
-            global.web3v1.utils.toWei("0.2")
+            web3.utils.toWei("0.2")
         );
 
-        await Promise.all([rates.setRate("EUR", 99000), testHelpers.waitForTimeStamp(loan.maturity)]);
+        await Promise.all([rates.setRate(EUR, 99000), testHelpers.waitForTimeStamp(loan.maturity)]);
 
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
 
-    it("Should collect a defaulted A-EUR loan when no leftover collateral (collection partially covered)", async function() {
-        await rates.setRate("EUR", 100000);
+    it("Should collect a defaulted A-EUR loan when no leftover collateral (collection partially covered)", async function () {
+        await rates.setRate(EUR, 100000);
         const loan = await loanTestHelpers.createLoan(
             this,
             products.defaultingNoLeftOver,
             accounts[1],
-            global.web3v1.utils.toWei("0.2")
+            web3.utils.toWei("0.2")
         );
 
-        await Promise.all([rates.setRate("EUR", 98900), testHelpers.waitForTimeStamp(loan.maturity)]);
+        await Promise.all([rates.setRate(EUR, 98900), testHelpers.waitForTimeStamp(loan.maturity)]);
 
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
 
-    it("Should collect a defaulted A-EUR loan when no leftover collateral (only fee covered)", async function() {
-        await rates.setRate("EUR", 99800);
+    it("Should collect a defaulted A-EUR loan when no leftover collateral (only fee covered)", async function () {
+        await rates.setRate(EUR, 99800);
         const loan = await loanTestHelpers.createLoan(
             this,
             products.defaultingNoLeftOver,
             accounts[1],
-            global.web3v1.utils.toWei("0.2")
+            web3.utils.toWei("0.2")
         );
-        await Promise.all([rates.setRate("EUR", 1), testHelpers.waitForTimeStamp(loan.maturity)]);
+        await Promise.all([rates.setRate(EUR, 1), testHelpers.waitForTimeStamp(loan.maturity)]);
 
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
-        await rates.setRate("EUR", 99800); // restore rates
+        await rates.setRate(EUR, 99800); // restore rates
     });
 
-    it("Should get and collect a loan with discountRate = 1 (zero interest)", async function() {
+    it("Should get and collect a loan with discountRate = 1 (zero interest)", async function () {
         const loan = await loanTestHelpers.createLoan(
             this,
             products.zeroInterest,
             accounts[0],
-            global.web3v1.utils.toWei("0.05")
+            web3.utils.toWei("0.05")
         );
         await testHelpers.waitForTimeStamp(loan.maturity);
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
 
-    it("Should get and collect a loan with discountRate > 1 (negative interest)", async function() {
+    it("Should get and collect a loan with discountRate > 1 (negative interest)", async function () {
         const loan = await loanTestHelpers.createLoan(
             this,
             products.negativeInterest,
             accounts[0],
-            global.web3v1.utils.toWei("0.05")
+            web3.utils.toWei("0.05")
         );
         await testHelpers.waitForTimeStamp(loan.maturity);
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
 
-    it("Should get and collect a loan with initialCollateralRatio = 1", async function() {
+    it("Should get and collect a loan with initialCollateralRatio = 1", async function () {
         const loan = await loanTestHelpers.createLoan(
             this,
             products.fullCoverage,
             accounts[0],
-            global.web3v1.utils.toWei("0.05")
+            web3.utils.toWei("0.05")
         );
         await testHelpers.waitForTimeStamp(loan.maturity);
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
 
-    it("Should get and collect a loan with initialCollateralRatio < 1", async function() {
+    it("Should get and collect a loan with initialCollateralRatio < 1", async function () {
         const loan = await loanTestHelpers.createLoan(
             this,
             products.moreCoverage,
             accounts[0],
-            global.web3v1.utils.toWei("0.05")
+            web3.utils.toWei("0.05")
         );
         await testHelpers.waitForTimeStamp(loan.maturity);
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
 
-    it("Should collect multiple defaulted loans", async function() {
+    it("Should collect multiple defaulted loans", async function () {
         const loanCount = (await loanManager.getLoanCount()).toNumber();
         await Promise.all([
-            loanManager.newEthBackedLoan(products.zeroInterest.id, 0 ,{
+            loanManager.newEthBackedLoan(products.zeroInterest.id, 0, {
                 from: accounts[0],
-                value: global.web3v1.utils.toWei("0.05")
+                value: web3.utils.toWei("0.05"),
             }),
             loanManager.newEthBackedLoan(products.fullCoverage.id, 0, {
                 from: accounts[1],
-                value: global.web3v1.utils.toWei("0.05")
+                value: web3.utils.toWei("0.05"),
             }),
             loanManager.newEthBackedLoan(products.negativeInterest.id, 0, {
                 from: accounts[1],
-                value: global.web3v1.utils.toWei("0.05")
-            })
+                value: web3.utils.toWei("0.05"),
+            }),
         ]);
 
         await testHelpers.waitFor(1000);
@@ -189,17 +186,17 @@ contract("Loans collection tests", accounts => {
         testHelpers.logGasUse(this, tx, "collect 3");
     });
 
-    it("Should NOT collect multiple loans if one is not due", async function() {
+    it("Should NOT collect multiple loans if one is not due", async function () {
         const loanCount = (await loanManager.getLoanCount()).toNumber();
         await Promise.all([
             loanManager.newEthBackedLoan(products.notDue.id, 0, {
                 from: accounts[0],
-                value: global.web3v1.utils.toWei("0.05")
+                value: web3.utils.toWei("0.05"),
             }),
             loanManager.newEthBackedLoan(products.defaulting.id, 0, {
                 from: accounts[1],
-                value: global.web3v1.utils.toWei("0.05")
-            })
+                value: web3.utils.toWei("0.05"),
+            }),
         ]);
 
         await testHelpers.waitFor(1000);
@@ -207,37 +204,27 @@ contract("Loans collection tests", accounts => {
         await testHelpers.expectThrow(loanManager.collect([loanCount, loanCount + 1]));
     });
 
-    it("Should NOT collect a loan before it's due", async function() {
-        const loan = await loanTestHelpers.createLoan(
-            this,
-            products.notDue,
-            accounts[1],
-            global.web3v1.utils.toWei("0.05")
-        );
+    it("Should NOT collect a loan before it's due", async function () {
+        const loan = await loanTestHelpers.createLoan(this, products.notDue, accounts[1], web3.utils.toWei("0.05"));
         await testHelpers.expectThrow(loanManager.collect([loan.id]));
     });
 
-    it("Should not collect when rate = 0", async function() {
-        await rates.setRate("EUR", 99800);
+    it("Should not collect when rate = 0", async function () {
+        await rates.setRate(EUR, 99800);
         const loan = await loanTestHelpers.createLoan(
             this,
             products.defaultingNoLeftOver,
             accounts[1],
-            global.web3v1.utils.toWei("0.05")
+            web3.utils.toWei("0.05")
         );
-        await Promise.all([rates.setRate("EUR", 0), testHelpers.waitForTimeStamp(loan.maturity)]);
+        await Promise.all([rates.setRate(EUR, 0), testHelpers.waitForTimeStamp(loan.maturity)]);
 
         testHelpers.expectThrow(loanTestHelpers.collectLoan(this, loan, accounts[2]));
-        await rates.setRate("EUR", 99800);
+        await rates.setRate(EUR, 99800);
     });
 
-    it("Should NOT collect an already collected loan", async function() {
-        const loan = await loanTestHelpers.createLoan(
-            this,
-            products.defaulting,
-            accounts[1],
-            global.web3v1.utils.toWei("0.05")
-        );
+    it("Should NOT collect an already collected loan", async function () {
+        const loan = await loanTestHelpers.createLoan(this, products.defaulting, accounts[1], web3.utils.toWei("0.05"));
 
         await testHelpers.waitForTimeStamp(loan.maturity);
 
@@ -245,7 +232,7 @@ contract("Loans collection tests", accounts => {
         await testHelpers.expectThrow(loanManager.collect([loan.id]));
     });
 
-    it("only allowed contract should call MonetarySupervisor.loanCollectionNotification", async function() {
+    it("only allowed contract should call MonetarySupervisor.loanCollectionNotification", async function () {
         await testHelpers.expectThrow(monetarySupervisor.loanCollectionNotification(0, { from: accounts[0] }));
     });
 
@@ -258,66 +245,51 @@ contract("Loans collection tests", accounts => {
     // 120% => 3742.5 (token)   => @ 74850 (token/eth)  => marginCallRate: 74832 (due to internal rounding in contract)
     // 160% => 4990 (token)     => @ 99800 (token/eth)
 
-    it("Should collect a loan if under margin", async function() {
-        await rates.setRate("EUR", 99800);
-        const loan = await loanTestHelpers.createLoan(
-            this,
-            products.margin,
-            accounts[1],
-            global.web3v1.utils.toWei("0.05")
-        );
-        await rates.setRate("EUR", 74830);
-        assert(await isCollectable(loan.id) === 1);
+    it("Should collect a loan if under margin", async function () {
+        await rates.setRate(EUR, 99800);
+        const loan = await loanTestHelpers.createLoan(this, products.margin, accounts[1], web3.utils.toWei("0.05"));
+        await rates.setRate(EUR, 74830);
+        assert((await isCollectable(loan.id)) === 1);
         await loanTestHelpers.collectLoan(this, loan, accounts[2]);
     });
 
-    it("Should not collect a loan if above margin", async function() {
-        await rates.setRate("EUR", 99800);
-        const loan = await loanTestHelpers.createLoan(
-            this,
-            products.margin,
-            accounts[1],
-            global.web3v1.utils.toWei("0.05")
-        );
-        await rates.setRate("EUR", 74840);
-        assert(await isCollectable(loan.id) === 0);
+    it("Should not collect a loan if above margin", async function () {
+        await rates.setRate(EUR, 99800);
+        const loan = await loanTestHelpers.createLoan(this, products.margin, accounts[1], web3.utils.toWei("0.05"));
+        await rates.setRate(EUR, 74840);
+        assert((await isCollectable(loan.id)) === 0);
         await testHelpers.expectThrow(loanManager.collect([loan.id]));
     });
 
-    it("Should not collect a loan if enough extra collateral was added", async function() {
-        await rates.setRate("EUR", 99800);
-        const loan = await loanTestHelpers.createLoan(
-            this,
-            products.margin,
-            accounts[1],
-            global.web3v1.utils.toWei("0.05")
-        );
-        assert(await isCollectable(loan.id) === 0);
+    it("Should not collect a loan if enough extra collateral was added", async function () {
+        await rates.setRate(EUR, 99800);
+        const loan = await loanTestHelpers.createLoan(this, products.margin, accounts[1], web3.utils.toWei("0.05"));
+        assert((await isCollectable(loan.id)) === 0);
 
         // set rate below margin
-        await rates.setRate("EUR", 72000);
-        assert(await isCollectable(loan.id) === 1);
+        await rates.setRate(EUR, 72000);
+        assert((await isCollectable(loan.id)) === 1);
 
         // add extra collateral to get above margin
         const tx = await loanManager.addExtraCollateral(loan.id, {
             from: accounts[1],
-            value: global.web3v1.utils.toWei("0.05")
+            value: web3.utils.toWei("0.05"),
         });
         testHelpers.logGasUse(this, tx, "addExtraCollateral");
 
         testHelpers.assertEvent(loanManager, "LoanChanged", {
-            loanId: loan.id,
+            loanId: loan.id.toString(),
             borrower: loan.borrower,
-            collateralAmount: global.web3v1.utils.toWei("0.1").toString(),
+            collateralAmount: web3.utils.toWei("0.1").toString(),
             repaymentAmount: loan.repaymentAmount.toString(),
-            currentRate: (await rates.rates("EUR"))[0].toString()
+            currentRate: (await rates.rates(EUR))[0].toString(),
         });
 
         // should not be collectable
-        assert(await isCollectable(loan.id) === 0);
+        assert((await isCollectable(loan.id)) === 0);
         await testHelpers.expectThrow(loanManager.collect([loan.id]));
     });
 
-    const isCollectable = async loanId =>
+    const isCollectable = async (loanId) =>
         loanTestHelpers.parseLoansInfo(await loanManager.getLoans(loanId, 1))[0].isCollectable.toNumber();
 });

--- a/test/loans.js
+++ b/test/loans.js
@@ -1,4 +1,3 @@
-const BigNumber = require("bignumber.js");
 const LoanManager = artifacts.require("./LoanManager.sol");
 
 const testHelpers = require("./helpers/testHelpers.js");
@@ -6,10 +5,14 @@ const tokenTestHelpers = require("./helpers/tokenTestHelpers.js");
 const loanTestHelpers = require("./helpers/loanTestHelpers.js");
 const ratesTestHelpers = require("./helpers/ratesTestHelpers.js");
 
+const BN = web3.utils.BN;
+
 let augmintToken = null;
 let loanManager = null;
 let monetarySupervisor = null;
 let rates = null;
+
+const EUR = web3.utils.asciiToHex("EUR");
 
 const ltdParams = { lockDifferenceLimit: 300000, loanDifferenceLimit: 200000, allowedDifferenceAmount: 1000000 };
 
@@ -19,22 +22,24 @@ let CHUNK_SIZE = 10;
 let snapshotIdSingleTest;
 let snapshotIdAllTests;
 
-contract("Loans tests", accounts => {
-    before(async function() {
-        snapshotIdAllTests = await testHelpers.takeSnapshot();
+contract("Loans tests", (accounts) => {
+    before(async function () {
+        [snapshotIdAllTests, rates, monetarySupervisor, augmintToken, loanManager] = await Promise.all([
+            testHelpers.takeSnapshot(),
 
-        rates = ratesTestHelpers.rates;
-        monetarySupervisor = tokenTestHelpers.monetarySupervisor;
-        augmintToken = tokenTestHelpers.augmintToken;
-        loanManager = loanTestHelpers.loanManager;
+            ratesTestHelpers.rates,
+            tokenTestHelpers.monetarySupervisor,
+            tokenTestHelpers.augmintToken,
+            loanTestHelpers.loanManager,
+        ]);
 
         const [prodCount] = await Promise.all([
-            loanManager.getProductCount().then(res => res.toNumber()),
+            loanManager.getProductCount().then((res) => res.toNumber()),
             monetarySupervisor.setLtdParams(
                 ltdParams.lockDifferenceLimit,
                 ltdParams.loanDifferenceLimit,
                 ltdParams.allowedDifferenceAmount
-            )
+            ),
         ]);
         // These neeed to be sequential b/c product order assumed when retrieving via getProducts
         // term (in sec), discountRate, initialCollateralRatio, minDisbursedAmount (w/ 2 decimals), defaultingFeePt, isActive, minCollateralRatio
@@ -50,7 +55,7 @@ contract("Loans tests", accounts => {
 
         const [newProducts] = await Promise.all([
             loanTestHelpers.getProductsInfo(prodCount, CHUNK_SIZE),
-            tokenTestHelpers.issueToken(accounts[0], accounts[0], 1000000000)
+            tokenTestHelpers.issueToken(accounts[0], accounts[0], 1000000000),
         ]);
         [
             products.notDue,
@@ -61,7 +66,7 @@ contract("Loans tests", accounts => {
             products.negativeInterest,
             products.fullCoverage,
             products.moreCoverage,
-            products.margin
+            products.margin,
         ] = newProducts;
     });
 
@@ -69,143 +74,130 @@ contract("Loans tests", accounts => {
         await testHelpers.revertSnapshot(snapshotIdAllTests);
     });
 
-    beforeEach(async function() {
+    beforeEach(async function () {
         snapshotIdSingleTest = await testHelpers.takeSnapshot();
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
         await testHelpers.revertSnapshot(snapshotIdSingleTest);
     });
 
-    it("Should get an A-EUR loan", async function() {
-        await loanTestHelpers.createLoan(this, products.repaying, accounts[0], global.web3v1.utils.toWei("0.5"));
+    it("Should get an A-EUR loan", async function () {
+        await loanTestHelpers.createLoan(this, products.repaying, accounts[0], web3.utils.toWei("0.5"));
     });
 
-    it("Should get an A-EUR loan if current rate is not below minRate", async function() {
+    it("Should get an A-EUR loan if current rate is not below minRate", async function () {
         const minRate = 22020;
-        await rates.setRate("EUR", minRate);
-        await loanTestHelpers.createLoan(this, products.repaying, accounts[1], global.web3v1.utils.toWei("0.5"), minRate);
+        await rates.setRate(EUR, minRate);
+        await loanTestHelpers.createLoan(this, products.repaying, accounts[1], web3.utils.toWei("0.5"), minRate);
     });
 
-    it("Should NOT get an A-EUR loan if current rate is below minRate", async function() {
+    it("Should NOT get an A-EUR loan if current rate is below minRate", async function () {
         const minRate = 22020;
-        await rates.setRate("EUR", minRate - 1);
-        await testHelpers.expectThrow(loanManager.newEthBackedLoan(products.repaying.id, minRate, { from: accounts[1], value: global.web3v1.utils.toWei("0.5") }));
-    });
-
-    it("Should NOT get a loan less than minDisbursedAmount", async function() {
-        const prod = products.repaying;
-        const loanAmount = prod.minDisbursedAmount
-            .sub(1)
-            .div(prod.discountRate)
-            .mul(1000000)
-            .round(0, BigNumber.ROUND_DOWN);
-        const weiAmount = (await rates.convertToWei(tokenTestHelpers.peggedSymbol, loanAmount))
-            .div(prod.initialCollateralRatio)
-            .mul(1000000)
-            .round(0, BigNumber.ROUND_DOWN);
-
-        await testHelpers.expectThrow(loanManager.newEthBackedLoan(prod.id, 0, { from: accounts[0], value: weiAmount }));
-    });
-
-    it("Shouldn't get a loan for a disabled product", async function() {
+        await rates.setRate(EUR, minRate - 1);
         await testHelpers.expectThrow(
-            loanManager.newEthBackedLoan(products.disabledProduct.id, 0, {
-                from: accounts[0],
-                value: global.web3v1.utils.toWei("0.05")
+            loanManager.newEthBackedLoan(products.repaying.id, minRate, {
+                from: accounts[1],
+                value: web3.utils.toWei("0.5"),
             })
         );
     });
 
-    it("Should repay an A-EUR loan before maturity", async function() {
-        const loan = await loanTestHelpers.createLoan(
-            this,
-            products.notDue,
-            accounts[1],
-            global.web3v1.utils.toWei("0.05")
+    it("Should NOT get a loan less than minDisbursedAmount", async function () {
+        const prod = products.repaying;
+        const loanAmount = prod.minDisbursedAmount.sub(new BN(1)).div(prod.discountRate).mul(testHelpers.PPM_DIV);
+        const weiAmount = (await rates.convertToWei(tokenTestHelpers.peggedSymbol, loanAmount))
+            .mul(testHelpers.PPM_DIV)
+            .div(prod.initialCollateralRatio);
+
+        await testHelpers.expectThrow(
+            loanManager.newEthBackedLoan(prod.id, 0, { from: accounts[0], value: weiAmount })
         );
+    });
+
+    it("Shouldn't get a loan for a disabled product", async function () {
+        await testHelpers.expectThrow(
+            loanManager.newEthBackedLoan(products.disabledProduct.id, 0, {
+                from: accounts[0],
+                value: web3.utils.toWei("0.05"),
+            })
+        );
+    });
+
+    it("Should repay an A-EUR loan before maturity", async function () {
+        const loan = await loanTestHelpers.createLoan(this, products.notDue, accounts[1], web3.utils.toWei("0.05"));
         // send interest to borrower to have enough A-EUR to repay in test
         await augmintToken.transfer(loan.borrower, loan.interestAmount, {
-            from: accounts[0]
+            from: accounts[0],
         });
         await loanTestHelpers.repayLoan(this, loan);
     });
 
-    it("Should get and repay a loan whith discountRate = 1 (zero interest)", async function() {
+    it("Should get and repay a loan whith discountRate = 1 (zero interest)", async function () {
         const loan = await loanTestHelpers.createLoan(
             this,
             products.zeroInterest,
             accounts[0],
-            global.web3v1.utils.toWei("0.05")
+            web3.utils.toWei("0.05")
         );
         await loanTestHelpers.repayLoan(this, loan);
     });
 
-    it("Should get and repay a loan whith discountRate > 1 (negative interest)", async function() {
+    it("Should get and repay a loan whith discountRate > 1 (negative interest)", async function () {
         const loan = await loanTestHelpers.createLoan(
             this,
             products.negativeInterest,
             accounts[0],
-            global.web3v1.utils.toWei("0.05")
+            web3.utils.toWei("0.05")
         );
         await loanTestHelpers.repayLoan(this, loan);
     });
 
-    it("Should get and repay a loan with colletaralRatio = 1", async function() {
+    it("Should get and repay a loan with colletaralRatio = 1", async function () {
         const loan = await loanTestHelpers.createLoan(
             this,
             products.fullCoverage,
             accounts[0],
-            global.web3v1.utils.toWei("0.05")
+            web3.utils.toWei("0.05")
         );
         await loanTestHelpers.repayLoan(this, loan);
     });
 
-    it("Should get and repay a loan with colletaralRatio > 1", async function() {
+    it("Should get and repay a loan with colletaralRatio > 1", async function () {
         const loan = await loanTestHelpers.createLoan(
             this,
             products.moreCoverage,
             accounts[0],
-            global.web3v1.utils.toWei("0.05")
+            web3.utils.toWei("0.05")
         );
         await loanTestHelpers.repayLoan(this, loan);
     });
 
-    it("Non owner should be able to repay a loan too", async function() {
-        const loan = await loanTestHelpers.createLoan(
-            this,
-            products.notDue,
-            accounts[1],
-            global.web3v1.utils.toWei("0.05")
-        );
+    it("Non owner should be able to repay a loan too", async function () {
+        const loan = await loanTestHelpers.createLoan(this, products.notDue, accounts[1], web3.utils.toWei("0.05"));
 
         await augmintToken.transferAndNotify(loanManager.address, loan.repaymentAmount, loan.id, {
-            from: accounts[0]
+            from: accounts[0],
         });
 
-        const currentRate = (await rates.rates("EUR"))[0].toNumber();
+        const currentRate = (await rates.rates(EUR))[0].toNumber();
         await testHelpers.assertEvent(loanManager, "LoanRepaid", {
-            loanId: loan.id,
+            loanId: loan.id.toString(),
             borrower: loan.borrower,
-            currentRate: currentRate
+            currentRate: currentRate.toString(),
         });
     });
 
-    it("Should NOT repay an A-EUR loan on maturity if A-EUR balance is insufficient", async function() {
+    it("Should NOT repay an A-EUR loan on maturity if A-EUR balance is insufficient", async function () {
         const borrower = accounts[2];
-        const loan = await loanTestHelpers.createLoan(
-            this,
-            products.notDue,
-            borrower,
-            global.web3v1.utils.toWei("0.05")
-        );
+        const loan = await loanTestHelpers.createLoan(this, products.notDue, borrower, web3.utils.toWei("0.05"));
         const accBal = await augmintToken.balanceOf(borrower);
 
         // send just 0.01 A€ less than required for repayment
-        const topUp = loan.repaymentAmount.sub(accBal).sub(1);
+        const topUp = loan.repaymentAmount.sub(accBal).sub(new BN(1));
         assert(accBal.add(topUp).lt(loan.repaymentAmount)); // sanitiy against previous tests accidently leaving A€ borrower account
         await augmintToken.transfer(borrower, topUp, {
-            from: accounts[0]
+            from: accounts[0],
         });
 
         await testHelpers.expectThrow(
@@ -213,70 +205,60 @@ contract("Loans tests", accounts => {
         );
     });
 
-    it("should not repay a loan with smaller amount than repaymentAmount", async function() {
+    it("should not repay a loan with smaller amount than repaymentAmount", async function () {
         const borrower = accounts[1];
-        const loan = await loanTestHelpers.createLoan(
-            this,
-            products.notDue,
-            borrower,
-            global.web3v1.utils.toWei("0.05")
-        );
+        const loan = await loanTestHelpers.createLoan(this, products.notDue, borrower, web3.utils.toWei("0.05"));
 
         await augmintToken.transfer(loan.borrower, loan.interestAmount, {
-            from: accounts[0]
+            from: accounts[0],
         });
 
         await testHelpers.expectThrow(
-            augmintToken.transferAndNotify(loanManager.address, loan.repaymentAmount.sub(1), loan.id, {
-                from: borrower
+            augmintToken.transferAndNotify(loanManager.address, loan.repaymentAmount.sub(new BN(1)), loan.id, {
+                from: borrower,
             })
         );
     });
 
-    it("Should not repay with invalid loanId", async function() {
+    it("Should not repay with invalid loanId", async function () {
         const loanCount = await loanManager.getLoanCount();
         await testHelpers.expectThrow(augmintToken.transferAndNotify(loanManager.address, 10000, loanCount));
     });
 
-    it("Should NOT repay a loan after maturity", async function() {
+    it("Should NOT repay a loan after maturity", async function () {
         const borrower = accounts[0];
-        const loan = await loanTestHelpers.createLoan(
-            this,
-            products.defaulting,
-            borrower,
-            global.web3v1.utils.toWei("0.05")
-        );
+        const loan = await loanTestHelpers.createLoan(this, products.defaulting, borrower, web3.utils.toWei("0.05"));
 
         const [accBal] = await Promise.all([
             augmintToken.balanceOf(borrower),
-            testHelpers.waitForTimeStamp(loan.maturity + 1)
+            testHelpers.waitForTimeStamp(loan.maturity + 1),
         ]);
         assert(accBal.gt(loan.repaymentAmount)); // sanitiy to make sure repayment is not failing on insufficient A€
 
         await testHelpers.expectThrow(
             augmintToken.transferAndNotify(loanManager.address, loan.repaymentAmount, loan.id, {
-                from: borrower
+                from: borrower,
             })
         );
     });
 
-    it("Should not get a loan when rates = 0", async function() {
-        await rates.setRate("EUR", 0);
+    it("Should not get a loan when rates = 0", async function () {
+        await rates.setRate(EUR, 0);
         await testHelpers.expectThrow(
             loanManager.newEthBackedLoan(products.repaying.id, 0, {
                 from: accounts[1],
-                value: global.web3v1.utils.toWei("0.1")
+                value: web3.utils.toWei("0.1"),
             })
         );
-        await rates.setRate("EUR", 99800); // restore rates
+        await rates.setRate(EUR, 99800); // restore rates
     });
 
-    it("Should list loans from offset", async function() {
+    it("Should list loans from offset", async function () {
         const product = products.repaying;
         const product2 = products.defaulting;
 
-        const loan1 = await loanTestHelpers.createLoan(this, product, accounts[1], global.web3v1.utils.toWei("0.05"));
-        const loan2 = await loanTestHelpers.createLoan(this, product2, accounts[2], global.web3v1.utils.toWei("0.06"));
+        const loan1 = await loanTestHelpers.createLoan(this, product, accounts[1], web3.utils.toWei("0.05"));
+        const loan2 = await loanTestHelpers.createLoan(this, product2, accounts[2], web3.utils.toWei("0.06"));
 
         await testHelpers.waitForTimeStamp(loan2.maturity);
 
@@ -288,17 +270,17 @@ contract("Loans tests", accounts => {
 
         const loan1Actual = loanInfo[0];
 
-        assert.equal(loan1Actual.id.toNumber(), loan1.id);
-        assert.equal(loan1Actual.collateralAmount.toNumber(), loan1.collateralAmount);
-        assert.equal(loan1Actual.repaymentAmount.toNumber(), loan1.repaymentAmount);
+        assert.equal(loan1Actual.id.toString(), loan1.id.toString());
+        assert.equal(loan1Actual.collateralAmount.toString(), loan1.collateralAmount.toString());
+        assert.equal(loan1Actual.repaymentAmount.toString(), loan1.repaymentAmount.toString());
         assert.equal(
             "0x" + loan1Actual.borrower.toString(16).padStart(40, "0"), // leading 0s if address starts with 0
-            loan1.borrower
+            loan1.borrower.toLowerCase()
         );
-        assert.equal(loan1Actual.productId.toNumber(), product.id);
-        assert.equal(loan1Actual.state.toNumber(), loan1.state);
-        assert.equal(loan1Actual.isCollectable.toNumber(), 0);
-        assert.equal(loan1Actual.maturity.toNumber(), loan1.maturity);
+        assert.equal(loan1Actual.productId.toString(), product.id.toString());
+        assert.equal(loan1Actual.state.toString(), loan1.state.toString());
+        assert.equal(loan1Actual.isCollectable.toString(), "0");
+        assert.equal(loan1Actual.maturity.toString(), loan1.maturity.toString());
         assert.equal(loan1Actual.disbursementTime.toNumber(), loan1.maturity - product.term);
         assert.equal(loan1Actual.loanAmount.toNumber(), loan1.loanAmount);
         assert.equal(loan1Actual.interestAmount.toNumber(), loan1.interestAmount);
@@ -308,19 +290,19 @@ contract("Loans tests", accounts => {
         assert.equal(loan2Actual.id.toNumber(), loan2.id);
         assert.equal(
             "0x" + loan2Actual.borrower.toString(16).padStart(40, "0"), // leading 0s if address starts with 0
-            loan2.borrower
+            loan2.borrower.toLowerCase()
         );
         assert.equal(loan2Actual.state.toNumber(), 0); // Open (defaulted but not yet collected)
         assert.equal(loan2Actual.isCollectable.toNumber(), 1);
     });
 
-    it("Should list loans for one account from offset", async function() {
+    it("Should list loans for one account from offset", async function () {
         const product1 = products.repaying;
         const product2 = products.defaulting;
         const borrower = accounts[1];
 
-        const loan1 = await loanTestHelpers.createLoan(this, product1, borrower, global.web3v1.utils.toWei("0.05"));
-        const loan2 = await loanTestHelpers.createLoan(this, product2, borrower, global.web3v1.utils.toWei("0.06"));
+        const loan1 = await loanTestHelpers.createLoan(this, product1, borrower, web3.utils.toWei("0.05"));
+        const loan2 = await loanTestHelpers.createLoan(this, product2, borrower, web3.utils.toWei("0.06"));
         const accountLoanCount = await loanManager.getLoanCountForAddress(borrower);
 
         await testHelpers.waitForTimeStamp(loan2.maturity);
@@ -333,12 +315,12 @@ contract("Loans tests", accounts => {
 
         const loan1Actual = loanInfo[0];
 
-        assert.equal(loan1Actual.id.toNumber(), loan1.id);
-        assert.equal(loan1Actual.collateralAmount.toNumber(), loan1.collateralAmount);
-        assert.equal(loan1Actual.repaymentAmount.toNumber(), loan1.repaymentAmount);
+        assert.equal(loan1Actual.id.toString(), loan1.id.toString());
+        assert.equal(loan1Actual.collateralAmount.toString(), loan1.collateralAmount.toString());
+        assert.equal(loan1Actual.repaymentAmount.toString(), loan1.repaymentAmount.toString());
         assert.equal(
             "0x" + loan1Actual.borrower.toString(16).padStart(40, "0"), // leading 0s if address starts with 0
-            loan1.borrower
+            loan1.borrower.toLowerCase()
         );
         assert.equal(loan1Actual.productId.toNumber(), product1.id);
         assert.equal(loan1Actual.state.toNumber(), loan1.state);
@@ -354,7 +336,7 @@ contract("Loans tests", accounts => {
         assert.equal(loan2Actual.isCollectable.toNumber(), 1);
     });
 
-    it("should only allow whitelisted loan contract to be used", async function() {
+    it("should only allow whitelisted loan contract to be used", async function () {
         const craftedLender = await LoanManager.new(
             accounts[0],
             augmintToken.address,
@@ -362,36 +344,36 @@ contract("Loans tests", accounts => {
             rates.address
         );
         await Promise.all([
-            await rates.setRate("EUR", 99800),
-            await craftedLender.grantPermission(accounts[0], "StabilityBoard")
+            await rates.setRate(EUR, 99800),
+            await craftedLender.grantPermission(accounts[0], web3.utils.asciiToHex("StabilityBoard")),
         ]);
         await craftedLender.addLoanProduct(100000, 1000000, 1000000, 1000, 50000, true, 0);
 
         // testing Lender not having "LoanManager" permission on monetarySupervisor:
-        await testHelpers.expectThrow(craftedLender.newEthBackedLoan(0, 0, { value: global.web3v1.utils.toWei("0.05") }));
+        await testHelpers.expectThrow(craftedLender.newEthBackedLoan(0, 0, { value: web3.utils.toWei("0.05") }));
 
         // grant permission to create new loan
-        await monetarySupervisor.grantPermission(craftedLender.address, "LoanManager");
-        await craftedLender.newEthBackedLoan(0, 0, { value: global.web3v1.utils.toWei("0.05") });
+        await monetarySupervisor.grantPermission(craftedLender.address, web3.utils.asciiToHex("LoanManager"));
+        await craftedLender.newEthBackedLoan(0, 0, { value: web3.utils.toWei("0.05") });
 
         // revoke permission and try to repay
-        await monetarySupervisor.revokePermission(craftedLender.address, "LoanManager"),
-        await testHelpers.expectThrow(
-            augmintToken.transferAndNotify(craftedLender.address, 99800, 0, {
-                from: accounts[0]
-            })
-        );
+        await monetarySupervisor.revokePermission(craftedLender.address, web3.utils.asciiToHex("LoanManager")),
+            await testHelpers.expectThrow(
+                augmintToken.transferAndNotify(craftedLender.address, 99800, 0, {
+                    from: accounts[0],
+                })
+            );
     });
 
-    it("should only allow the token contract to call transferNotification", async function() {
+    it("should only allow the token contract to call transferNotification", async function () {
         await testHelpers.expectThrow(loanManager.transferNotification(accounts[0], 1000, 0, { from: accounts[0] }));
     });
 
-    it("only allowed contract should call MonetarySupervisor.issueLoan", async function() {
+    it("only allowed contract should call MonetarySupervisor.issueLoan", async function () {
         await testHelpers.expectThrow(monetarySupervisor.issueLoan(accounts[0], 0, { from: accounts[0] }));
     });
 
-    it("only allowed contract should call MonetarySupervisor.loanRepaymentNotification", async function() {
+    it("only allowed contract should call MonetarySupervisor.loanRepaymentNotification", async function () {
         await testHelpers.expectThrow(monetarySupervisor.loanRepaymentNotification(0, { from: accounts[0] }));
     });
 
@@ -405,63 +387,58 @@ contract("Loans tests", accounts => {
     // 120% => 3742.5 (token)   => @ 74850 (token/eth)  => marginCallRate: 74832 (due to internal rounding in contract)
     // 160% => 4990 (token)     => @ 99800 (token/eth)
 
-    it("tests loan margin numbers", async function() {
-        await rates.setRate("EUR", 99800);
-        const loan = await loanTestHelpers.createLoan(
-            this,
-            products.margin,
-            accounts[1],
-            global.web3v1.utils.toWei("0.05")
-        );
+    it("tests loan margin numbers", async function () {
+        await rates.setRate(EUR, 99800);
+        const loan = await loanTestHelpers.createLoan(this, products.margin, accounts[1], web3.utils.toWei("0.05"));
 
         // assert event has proper numbers
-        assert.equal(loan.collateralAmount.toNumber(), 5e16);      // = 0.05 (eth)
-        assert.equal(loan.tokenValue.toNumber(), 4990);            // = 99800 * 0.05 (token)
-        assert.equal(loan.repaymentAmount.toNumber(), 3118);       // = 4990 / 1.6, round down (token)
-        assert.equal(loan.loanAmount.toNumber(), 3025);            // = 3118 * 0.97, round up (token)
-        assert.equal(loan.interestAmount.toNumber(), 93);          // = 3118 - 3025 (token)
-        assert.equal(loan.state, 0);                               // = "Open"
+        assert.equal(loan.collateralAmount.toString(), (5e16).toString()); // = 0.05 (eth)
+        assert.equal(loan.tokenValue.toNumber(), 4990); // = 99800 * 0.05 (token)
+        assert.equal(loan.repaymentAmount.toNumber(), 3118); // = 4990 / 1.6, round down (token)
+        assert.equal(loan.loanAmount.toNumber(), 3025); // = 3118 * 0.97, round up (token)
+        assert.equal(loan.interestAmount.toNumber(), 93); // = 3118 - 3025 (token)
+        assert.equal(loan.state, 0); // = "Open"
         assert.equal(loan.currentRate, 99800);
 
         // assert LoanData has proper numbers stored
         const loanInfo = loanTestHelpers.parseLoansInfo(await loanManager.getLoans(loan.id, 1));
-        assert.equal(loanInfo[0].collateralAmount.toNumber(), 5e16);
+        assert.equal(loanInfo[0].collateralAmount.toString(), (5e16).toString());
         assert.equal(loanInfo[0].repaymentAmount.toNumber(), 3118);
         assert.equal(loanInfo[0].state.toNumber(), 0);
         assert.equal(loanInfo[0].loanAmount.toNumber(), 3025);
         assert.equal(loanInfo[0].interestAmount.toNumber(), 93);
-        assert.equal(loanInfo[0].marginCallRate.toNumber(), 74832);    // = 3118 * 1.2 / 0.05 (token/eth)
-        assert.equal(loanInfo[0].isCollectable.toNumber(), 0);         // = false
+        assert.equal(loanInfo[0].marginCallRate.toNumber(), 74832); // = 3118 * 1.2 / 0.05 (token/eth)
+        assert.equal(loanInfo[0].isCollectable.toNumber(), 0); // = false
 
         // every number stays the same below margin, only isCollectable will be true
-        await rates.setRate("EUR", 72000);
+        await rates.setRate(EUR, 72000);
         const loanInfo2 = loanTestHelpers.parseLoansInfo(await loanManager.getLoans(loan.id, 1));
-        assert.equal(loanInfo2[0].collateralAmount.toNumber(), 5e16);
+        assert.equal(loanInfo2[0].collateralAmount.toString(), (5e16).toString());
         assert.equal(loanInfo2[0].repaymentAmount.toNumber(), 3118);
         assert.equal(loanInfo2[0].state.toNumber(), 0);
         assert.equal(loanInfo2[0].loanAmount.toNumber(), 3025);
         assert.equal(loanInfo2[0].interestAmount.toNumber(), 93);
         assert.equal(loanInfo2[0].marginCallRate.toNumber(), 74832);
-        assert.equal(loanInfo2[0].isCollectable.toNumber(), 1);        // = true
+        assert.equal(loanInfo2[0].isCollectable.toNumber(), 1); // = true
 
         // add extra collateral to get above margin
         const tx = await loanManager.addExtraCollateral(loan.id, {
             from: accounts[1],
-            value: global.web3v1.utils.toWei("0.05")
+            value: web3.utils.toWei("0.05"),
         });
         testHelpers.logGasUse(this, tx, "addExtraCollateral");
 
         testHelpers.assertEvent(loanManager, "LoanChanged", {
-            loanId: loan.id,
+            loanId: loan.id.toString(),
             borrower: loan.borrower,
-            collateralAmount: global.web3v1.utils.toWei("0.1").toString(),
+            collateralAmount: web3.utils.toWei("0.1").toString(),
             repaymentAmount: loan.repaymentAmount.toString(),
-            currentRate: (await rates.rates("EUR"))[0].toString()
+            currentRate: (await rates.rates(EUR))[0].toString(),
         });
 
         // collateralAmount should double up, marginCallRate get halved
         const loanInfo3 = loanTestHelpers.parseLoansInfo(await loanManager.getLoans(loan.id, 1));
-        assert.equal(loanInfo3[0].collateralAmount.toNumber(), 2 * 5e16);
+        assert.equal(loanInfo3[0].collateralAmount.toString(), (2 * 5e16).toString());
         assert.equal(loanInfo3[0].repaymentAmount.toNumber(), 3118);
         assert.equal(loanInfo3[0].state.toNumber(), 0);
         assert.equal(loanInfo3[0].loanAmount.toNumber(), 3025);

--- a/test/locker.js
+++ b/test/locker.js
@@ -4,6 +4,8 @@ const tokenTestHelpers = require("./helpers/tokenTestHelpers.js");
 
 const testHelpers = require("./helpers/testHelpers.js");
 
+const BN = web3.utils.BN;
+
 const LOCK_MAX_GAS = 230000;
 const RELEASE_MAX_GAS = 80000;
 
@@ -16,16 +18,15 @@ let CHUNK_SIZE = 10;
 
 const ltdParams = { lockDifferenceLimit: 300000, loanDifferenceLimit: 200000, allowedDifferenceAmount: 100000 };
 
-contract("Lock", accounts => {
-    before(async function() {
+contract("Locker", (accounts) => {
+    before(async function () {
         tokenHolder = accounts[1];
 
-        augmintToken = await tokenTestHelpers.augmintToken;
+        [augmintToken, lockerInstance] = await Promise.all([tokenTestHelpers.augmintToken, Locker.at(Locker.address)]);
+
         monetarySupervisor = tokenTestHelpers.monetarySupervisor;
 
         interestEarnedAddress = tokenTestHelpers.interestEarnedAccount.address;
-
-        lockerInstance = Locker.at(Locker.address);
 
         await Promise.all([
             monetarySupervisor.setLtdParams(
@@ -34,11 +35,11 @@ contract("Lock", accounts => {
                 ltdParams.allowedDifferenceAmount
             ),
             tokenTestHelpers.issueToken(accounts[0], tokenHolder, 40000),
-            tokenTestHelpers.issueToken(accounts[0], interestEarnedAddress, 10000)
+            tokenTestHelpers.issueToken(accounts[0], interestEarnedAddress, 10000),
         ]);
     });
 
-    it("Verifies default test lockproduct interest rates", async function() {
+    it("Verifies default test lockproduct interest rates", async function () {
         // correlates with lock products set up in localTest_initialSetup.sol
 
         // IRPA: Interest Rate Per Annum : the percentage value on the UI
@@ -47,33 +48,33 @@ contract("Lock", accounts => {
         // IRPA = (PTI / 1_000_000) * (365 / termInDays)
         // PTI = (IRPA * 1_000_000) * (termInDays / 365)
 
-        const toPti = (irpa, termInDays) => Math.ceil((irpa * 1000000) * (termInDays / 365))
+        const toPti = (irpa, termInDays) => Math.ceil(irpa * 1000000 * (termInDays / 365));
 
         const p = await lockerInstance.getLockProducts(0, CHUNK_SIZE);
-        assert.equal(p[0][0].toNumber(), toPti(0.12, 365))
-        assert.equal(p[1][0].toNumber(), toPti(0.115, 180))
-        assert.equal(p[2][0].toNumber(), toPti(0.11, 90))
-        assert.equal(p[3][0].toNumber(), toPti(0.105, 60))
-        assert.equal(p[4][0].toNumber(), toPti(0.10, 30))
-        assert.equal(p[5][0].toNumber(), toPti(0.10, 14))
-        assert.equal(p[6][0].toNumber(), toPti(0.10, 7))
+        assert.equal(p[0][0].toNumber(), toPti(0.12, 365));
+        assert.equal(p[1][0].toNumber(), toPti(0.115, 180));
+        assert.equal(p[2][0].toNumber(), toPti(0.11, 90));
+        assert.equal(p[3][0].toNumber(), toPti(0.105, 60));
+        assert.equal(p[4][0].toNumber(), toPti(0.1, 30));
+        assert.equal(p[5][0].toNumber(), toPti(0.1, 14));
+        assert.equal(p[6][0].toNumber(), toPti(0.1, 7));
     });
 
-    it("should allow lock products to be created", async function() {
+    it("should allow lock products to be created", async function () {
         // create lock product with 5% per term, and 60 sec lock time:
         const tx = await lockerInstance.addLockProduct(50000, 60, 100, true);
         testHelpers.logGasUse(this, tx, "addLockProduct");
 
         await testHelpers.assertEvent(lockerInstance, "NewLockProduct", {
-            lockProductId: x => x,
-            perTermInterest: 50000,
-            durationInSecs: 60,
-            minimumLockAmount: 100,
-            isActive: true
+            lockProductId: (x) => x,
+            perTermInterest: "50000",
+            durationInSecs: "60",
+            minimumLockAmount: "100",
+            isActive: true,
         });
     });
 
-    it("should allow the number of lock products to be queried", async function() {
+    it("should allow the number of lock products to be queried", async function () {
         const startingNumLocks = (await lockerInstance.getLockProductCount()).toNumber();
 
         // create lock product with 5% per term, and 120 sec lock time:
@@ -85,33 +86,27 @@ contract("Lock", accounts => {
         assert(startingNumLocks + 1 === endNumLocks);
     });
 
-    it("should allow the getting of individual lock products", async function() {
+    it("should allow the getting of individual lock products", async function () {
         // create lock product with 8% per term, and 120 sec lock time:
         const tx = await lockerInstance.addLockProduct(80000, 120, 50, true);
         testHelpers.logGasUse(this, tx, "addLockProduct");
 
         const numLocks = (await lockerInstance.getLockProductCount()).toNumber();
 
-        const product = await lockerInstance.lockProducts(numLocks - 1);
+        const prod = await lockerInstance.lockProducts(numLocks - 1);
 
-        // each product should be a 4 element array
-        assert.isArray(product);
-        assert(product.length === 4);
-
-        // the product should be [ perTermInterest, durationInSecs, minimumLockAmount, isActive ]:
-        const [perTermInterest, durationInSecs, minimumLockAmount, isActive] = product;
-        assert(perTermInterest.toNumber() === 80000);
-        assert(durationInSecs.toNumber() === 120);
-        assert(minimumLockAmount.toNumber() === 50);
-        assert(isActive === true);
+        assert.equal(prod.perTermInterest, "80000");
+        assert.equal(prod.durationInSecs, "120");
+        assert.equal(prod.minimumLockAmount, "50");
+        assert(prod.isActive, "product should be  in active state");
     });
 
-    it("should allow the listing of lock products (0 offset)", async function() {
+    it("should allow the listing of lock products (0 offset)", async function () {
         // create lock product with 10% per term, and 120 sec lock time:
         const tx = await lockerInstance.addLockProduct(100000, 120, 75, true);
         testHelpers.logGasUse(this, tx, "addLockProduct");
 
-        const numLocks = await lockerInstance.getLockProductCount().then(res => res.toNumber());
+        const numLocks = await lockerInstance.getLockProductCount().then((res) => res.toNumber());
         const products = await lockerInstance.getLockProducts(0, numLocks);
 
         // getLockProducts should return a <numLocks> element array:
@@ -124,8 +119,7 @@ contract("Lock", accounts => {
         assert.isArray(newestProduct);
         assert(newestProduct.length === 5);
 
-        // the products should be [ perTermInterest, durationInSecs, maxLockAmount, isActive ] all
-        // represented as uints (i.e. BigNumber objects in JS land):
+        // the products should be [ perTermInterest, durationInSecs, maxLockAmount, isActive ]
         const [perTermInterest, durationInSecs, minimumLockAmount, maxLockAmount, isActive] = newestProduct;
         assert(perTermInterest.toNumber() === 100000);
         assert(durationInSecs.toNumber() === 120);
@@ -135,7 +129,7 @@ contract("Lock", accounts => {
         assert(isActive.toNumber() === 1);
     });
 
-    it("should allow the listing of lock products (non-zero offset)", async function() {
+    it("should allow the listing of lock products (non-zero offset)", async function () {
         const offset = 1;
 
         const products = await lockerInstance.getLockProducts(offset, CHUNK_SIZE);
@@ -147,39 +141,36 @@ contract("Lock", accounts => {
 
         // each product should be a 5 element array
         assert.isArray(product);
-        assert(product.length === 5);
+        assert.equal(product.length, 5, "number of products");
 
-        const expectedProduct = await lockerInstance.lockProducts(offset);
-        const [
-            expectedPerTermInterest,
-            expectedDurationInSecs,
-            expectedMinimumLockAmount,
-            expectedIsActive
-        ] = expectedProduct;
-
-        // the products should be [ perTermInterest, durationInSecs, maxLockAmount, isActive ] all
-        // represented as uints (i.e. BigNumber objects in JS land):
+        // the products should be [ perTermInterest, durationInSecs, maxLockAmount, isActive ]
         const [perTermInterest, durationInSecs, minimumLockAmount, maxLockAmount, isActive] = product;
-        const expMaxLockAmount = await monetarySupervisor.getMaxLockAmount(minimumLockAmount, perTermInterest);
 
-        assert(perTermInterest.toNumber() === expectedPerTermInterest.toNumber());
-        assert(durationInSecs.toNumber() === expectedDurationInSecs.toNumber());
-        assert(minimumLockAmount.toNumber() === expectedMinimumLockAmount.toNumber());
-        assert.equal(maxLockAmount.toString(), expMaxLockAmount.toString());
-        assert(!!isActive.toNumber() === expectedIsActive);
+        const expProd = await lockerInstance.lockProducts(offset);
+
+        const expMaxLockAmount = await monetarySupervisor.getMaxLockAmount(
+            expProd.minimumLockAmount,
+            expProd.perTermInterest
+        );
+
+        assert.equal(perTermInterest.toString(), expProd.perTermInterest.toString(), "perTermInterest");
+        assert.equal(durationInSecs.toString(), expProd.durationInSecs.toString(), "durationInSecs");
+        assert.equal(minimumLockAmount.toString(), expProd.minimumLockAmount.toString(), "minimumLockAmount");
+        assert.equal(maxLockAmount.toString(), expMaxLockAmount.toString(), "maxLockAmount");
+        assert.equal(isActive, expProd.isActive, "isActive");
     });
 
     it("should allow the listing of lock products when there are more than CHUNK_SIZE products");
 
-    it("should allow lock products to be enabled/disabled", async function() {
+    it("should allow lock products to be enabled/disabled", async function () {
         const lockProductId = 0;
 
         const tx = await lockerInstance.setLockProductActiveState(lockProductId, false);
         testHelpers.logGasUse(this, tx, "setLockProductActiveState");
 
         await testHelpers.assertEvent(lockerInstance, "LockProductActiveChange", {
-            lockProductId: lockProductId,
-            newActiveState: false
+            lockProductId: lockProductId.toString(),
+            newActiveState: false,
         });
 
         let product = await lockerInstance.lockProducts(lockProductId);
@@ -189,8 +180,8 @@ contract("Lock", accounts => {
         await lockerInstance.setLockProductActiveState(lockProductId, true);
 
         await testHelpers.assertEvent(lockerInstance, "LockProductActiveChange", {
-            lockProductId: lockProductId,
-            newActiveState: true
+            lockProductId: lockProductId.toString(),
+            newActiveState: true,
         });
 
         product = await lockerInstance.lockProducts(lockProductId);
@@ -198,14 +189,15 @@ contract("Lock", accounts => {
         assert(product[3] === true);
     });
 
-    it("should allow tokens to be locked", async function() {
-        const [startingBalances, totalLockAmountBefore] = await Promise.all([
+    it("should allow tokens to be locked", async function () {
+        const [startingBalances, totalLockAmountBefore, expectedLockId] = await Promise.all([
             tokenTestHelpers.getAllBalances({
                 tokenHolder: tokenHolder,
                 lockerInstance: lockerInstance.address,
-                interestEarned: interestEarnedAddress
+                interestEarned: interestEarnedAddress,
             }),
-            monetarySupervisor.totalLockedAmount()
+            monetarySupervisor.totalLockedAmount(),
+            lockerInstance.getLockCount(),
         ]);
         const amountToLock = 1000;
 
@@ -213,8 +205,8 @@ contract("Lock", accounts => {
         const [product, lockingTransaction] = await Promise.all([
             lockerInstance.lockProducts(0),
             augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, {
-                from: tokenHolder
-            })
+                from: tokenHolder,
+            }),
         ]);
         testHelpers.logGasUse(this, lockingTransaction, "transferAndNotify - lockFunds");
 
@@ -223,7 +215,7 @@ contract("Lock", accounts => {
         const interestEarned = Math.ceil((amountToLock * perTermInterest) / 1000000);
 
         // need the block to get the timestamp to check lockedUntil in NewLock event:
-        const block = await global.web3v1.eth.getBlock(lockingTransaction.receipt.blockHash);
+        const block = await web3.eth.getBlock(lockingTransaction.receipt.blockHash);
         const expectedLockedUntil = block.timestamp + durationInSecs;
         // sanity check:
         assert(expectedLockedUntil > Math.floor(Date.now() / 1000));
@@ -233,12 +225,12 @@ contract("Lock", accounts => {
 
             testHelpers.assertEvent(lockerInstance, "NewLock", {
                 lockOwner: tokenHolder,
-                lockId: 0,
-                amountLocked: amountToLock,
-                interestEarned: interestEarned,
-                lockedUntil: expectedLockedUntil,
-                perTermInterest: perTermInterest,
-                durationInSecs: durationInSecs
+                lockId: expectedLockId.toString(),
+                amountLocked: amountToLock.toString(),
+                interestEarned: interestEarned.toString(),
+                lockedUntil: expectedLockedUntil.toString(),
+                perTermInterest: perTermInterest.toString(),
+                durationInSecs: durationInSecs.toString(),
             }),
 
             // TODO: events are emitted but can't retrieve them
@@ -258,37 +250,37 @@ contract("Lock", accounts => {
 
             tokenTestHelpers.assertBalances(startingBalances, {
                 tokenHolder: {
-                    ace: startingBalances.tokenHolder.ace.sub(amountToLock),
-                    gasFee: LOCK_MAX_GAS * testHelpers.GAS_PRICE
+                    ace: startingBalances.tokenHolder.ace.sub(new BN(amountToLock)),
+                    gasFee: LOCK_MAX_GAS * testHelpers.GAS_PRICE,
                 },
-                lockerInstance: { ace: startingBalances.lockerInstance.ace.add(amountToLock + interestEarned) },
-                interestEarned: { ace: startingBalances.interestEarned.ace.sub(interestEarned) }
-            })
+                lockerInstance: { ace: startingBalances.lockerInstance.ace.add(new BN(amountToLock + interestEarned)) },
+                interestEarned: { ace: startingBalances.interestEarned.ace.sub(new BN(interestEarned)) },
+            }),
         ]);
 
         assert.equal(
             totalLockAmountAfter.toString(),
-            totalLockAmountBefore.add(amountToLock).toString(),
+            totalLockAmountBefore.add(new BN(amountToLock)).toString(),
             "totalLockedAmount should be increased by locked amount "
         );
     });
 
-    it("should not allow to lock with an inactive lockproduct", async function() {
+    it("should not allow to lock with an inactive lockproduct", async function () {
         await lockerInstance.addLockProduct(50000, 60, 100, false);
         const newLockProductId = (await lockerInstance.getLockProductCount()) - 1;
         await testHelpers.expectThrow(
             augmintToken.transferAndNotify(lockerInstance.address, 10000, newLockProductId, {
-                from: tokenHolder
+                from: tokenHolder,
             })
         );
     });
 
-    it("should allow an account to see how many locks it has", async function() {
+    it("should allow an account to see how many locks it has", async function () {
         const startingNumLocks = (await lockerInstance.getLockCountForAddress(tokenHolder)).toNumber();
         const amountToLock = 1000;
 
         await augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, {
-            from: tokenHolder
+            from: tokenHolder,
         });
 
         const finishingNumLocks = (await lockerInstance.getLockCountForAddress(tokenHolder)).toNumber();
@@ -296,15 +288,15 @@ contract("Lock", accounts => {
         assert(finishingNumLocks === startingNumLocks + 1);
     });
 
-    it("should allow tokens to be unlocked", async function() {
+    it("should allow tokens to be unlocked", async function () {
         const [startingBalances, addProdTx] = await Promise.all([
             tokenTestHelpers.getAllBalances({
                 tokenHolder: tokenHolder,
                 lockerInstance: lockerInstance.address,
-                interestEarned: interestEarnedAddress
+                interestEarned: interestEarnedAddress,
             }),
             // create lock product with 10% per term, and 1 sec lock time:
-            lockerInstance.addLockProduct(100000, 1, 0, true)
+            lockerInstance.addLockProduct(100000, 1, 0, true),
         ]);
         testHelpers.logGasUse(this, addProdTx, "addLockProduct");
 
@@ -313,13 +305,13 @@ contract("Lock", accounts => {
         const newLockProductId = (await lockerInstance.getLockProductCount()) - 1;
 
         const lockTx = await augmintToken.transferAndNotify(lockerInstance.address, amountToLock, newLockProductId, {
-            from: tokenHolder
+            from: tokenHolder,
         });
         testHelpers.logGasUse(this, lockTx, "transferAndNotify - lockFunds");
 
         const [totalLockAmountBefore, newestLockId] = await Promise.all([
             monetarySupervisor.totalLockedAmount(),
-            lockerInstance.getLockCount().then(res => res - 1)
+            lockerInstance.getLockCount().then((res) => res - 1),
         ]);
 
         const lockedUntil = (await lockerInstance.locks(newestLockId))[3].toNumber();
@@ -333,53 +325,53 @@ contract("Lock", accounts => {
 
             tokenTestHelpers.assertBalances(startingBalances, {
                 tokenHolder: {
-                    ace: startingBalances.tokenHolder.ace.add(interestEarned),
-                    gasFee: LOCK_MAX_GAS * testHelpers.GAS_PRICE + RELEASE_MAX_GAS * testHelpers.GAS_PRICE
+                    ace: startingBalances.tokenHolder.ace.add(new BN(interestEarned)),
+                    gasFee: LOCK_MAX_GAS * testHelpers.GAS_PRICE + RELEASE_MAX_GAS * testHelpers.GAS_PRICE,
                 },
                 lockerInstance: { ace: startingBalances.lockerInstance.ace },
-                interestEarned: { ace: startingBalances.interestEarned.ace.sub(interestEarned) }
+                interestEarned: { ace: startingBalances.interestEarned.ace.sub(new BN(interestEarned)) },
             }),
 
             testHelpers.assertEvent(lockerInstance, "LockReleased", {
                 lockOwner: tokenHolder,
-                lockId: newestLockId
+                lockId: newestLockId.toString(),
             }),
 
             testHelpers.assertEvent(augmintToken, "AugmintTransfer", {
                 from: lockerInstance.address,
                 to: tokenHolder,
-                amount: amountToLock + interestEarned,
-                fee: 0,
-                narrative: "Funds released from lock"
+                amount: (amountToLock + interestEarned).toString(),
+                fee: "0",
+                narrative: "Funds released from lock",
             }),
 
             testHelpers.assertEvent(augmintToken, "Transfer", {
                 from: lockerInstance.address,
                 to: tokenHolder,
-                amount: amountToLock + interestEarned
-            })
+                amount: (amountToLock + interestEarned).toString(),
+            }),
         ]);
 
         assert.equal(
             totalLockAmountAfter.toString(),
-            totalLockAmountBefore.sub(amountToLock).toString(),
+            totalLockAmountBefore.sub(new BN(amountToLock)).toString(),
             "totalLockedAmount should be the decrased by released amount (w/o interest) after release "
         );
     });
 
-    it("should allow an account to see it's individual locks", async function() {
+    it("should allow an account to see it's individual locks", async function () {
         const amountToLock = 1000;
 
         // lock funds, and get the product that was used:
         const [product, lockingTransaction] = await Promise.all([
             lockerInstance.lockProducts(0),
-            augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, { from: tokenHolder })
+            augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, { from: tokenHolder }),
         ]);
 
         const expectedDurationInSecs = product[1].toNumber();
 
         // need the block to get the timestamp to check lockedUntil in NewLock event:
-        const block = await global.web3v1.eth.getBlock(lockingTransaction.receipt.blockHash);
+        const block = await web3.eth.getBlock(lockingTransaction.receipt.blockHash);
         const expectedLockedUntil = block.timestamp + expectedDurationInSecs;
         // sanity check:
         assert(expectedLockedUntil > Math.floor(Date.now() / 1000));
@@ -387,28 +379,23 @@ contract("Lock", accounts => {
         const numLocks = (await lockerInstance.getLockCountForAddress(tokenHolder)).toNumber();
         const newestLock = await lockerInstance.locks(numLocks - 1);
 
-        // each lock should be a 5 element array
-        assert.isArray(newestLock);
-        assert.equal(newestLock.length, 5);
-
         // the locks should be [ amountLocked, owner, interestEarned, lockedUntil, perTermInterest, durationInSecs, isActive ]
-        const [amountLocked, owner, productId, lockedUntil, isActive] = newestLock;
-        assert(owner === tokenHolder);
-        assert(amountLocked.toNumber() === amountToLock);
-        assert(productId.toNumber() === 0);
-        assert(lockedUntil.toNumber() === expectedLockedUntil);
-        assert(isActive === true);
+        assert.equal(newestLock.owner, tokenHolder, "owner");
+        assert.equal(newestLock.amountLocked, amountToLock.toString(), "amountLocked");
+        assert.equal(newestLock.productId, "0", "productId");
+        assert.equal(newestLock.lockedUntil, expectedLockedUntil.toString(), "lockedUntil");
+        assert(newestLock.isActive, "isActive");
     });
 
     it("should allow to list all locks (0 offset)");
 
-    it("should allow to list all locks (non-zero offset)", async function() {
+    it("should allow to list all locks (non-zero offset)", async function () {
         const amountToLock = 1000;
         const [product, lockingTransaction, ,] = await Promise.all([
             lockerInstance.lockProducts(0),
             augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, { from: tokenHolder }),
             augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, { from: tokenHolder }),
-            augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, { from: tokenHolder })
+            augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, { from: tokenHolder }),
         ]);
 
         const expectedPerTermInterest = product[0].toNumber();
@@ -416,7 +403,7 @@ contract("Lock", accounts => {
         const expectedInterestEarned = Math.ceil((amountToLock * expectedPerTermInterest) / 1000000);
 
         // need the block to get the timestamp to check lockedUntil in NewLock event:
-        const block = await global.web3v1.eth.getBlock(lockingTransaction.receipt.blockHash);
+        const block = await web3.eth.getBlock(lockingTransaction.receipt.blockHash);
         const expectedLockedUntil = block.timestamp + expectedDurationInSecs;
         // sanity check:
         assert(expectedLockedUntil > Math.floor(Date.now() / 1000));
@@ -441,19 +428,19 @@ contract("Lock", accounts => {
             lockedUntil,
             perTermInterest,
             durationInSecs,
-            isActive
+            isActive,
         ] = lock2;
         assert.equal(lockId.toNumber(), lockId2);
         assert.equal(
             "0x" + owner.toString(16).padStart(40, "0"), // leading 0s if address starts with 0
-            tokenHolder
+            tokenHolder.toLowerCase()
         );
-        assert.equal(amountLocked.toNumber(), amountToLock);
-        assert.equal(interestEarned.toNumber(), expectedInterestEarned);
-        assert.isAtLeast(lockedUntil.toNumber(), expectedLockedUntil);
-        assert.equal(perTermInterest.toNumber(), expectedPerTermInterest);
-        assert.equal(durationInSecs.toNumber(), expectedDurationInSecs);
-        assert.equal(isActive.toNumber(), 1);
+        assert.equal(amountLocked.toNumber(), amountToLock, "amountLocked");
+        assert.equal(interestEarned.toNumber(), expectedInterestEarned, "interestEarned");
+        assert.isAtLeast(lockedUntil.toNumber(), expectedLockedUntil, "lockedUntil");
+        assert.equal(perTermInterest.toNumber(), expectedPerTermInterest, "perTermInterest");
+        assert.equal(durationInSecs.toNumber(), expectedDurationInSecs, "durationInSecs");
+        assert(isActive, "isActive");
 
         const lock3 = locks[1];
         assert.equal(lock3[0].toNumber(), lockId3);
@@ -461,7 +448,7 @@ contract("Lock", accounts => {
 
     it("should allow to list all locks when it has more than CHUNK_SIZE locks");
 
-    it("should allow to list an account's locks (0 offset)", async function() {
+    it("should allow to list an account's locks (0 offset)", async function () {
         // NB: this test assumes that tokenHolder has less than CHUNK_SIZE locks (when checking newestLock)
 
         const amountToLock = 1000;
@@ -469,7 +456,7 @@ contract("Lock", accounts => {
         // lock funds, and get the product that was used:
         const [product, lockingTransaction] = await Promise.all([
             lockerInstance.lockProducts(0),
-            augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, { from: tokenHolder })
+            augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, { from: tokenHolder }),
         ]);
 
         const expectedPerTermInterest = product[0].toNumber();
@@ -477,7 +464,7 @@ contract("Lock", accounts => {
         const expectedInterestEarned = Math.ceil((amountToLock * expectedPerTermInterest) / 1000000);
 
         // need the block to get the timestamp to check lockedUntil in NewLock event:
-        const block = await global.web3v1.eth.getBlock(lockingTransaction.receipt.blockHash);
+        const block = await web3.eth.getBlock(lockingTransaction.receipt.blockHash);
         const expectedLockedUntil = block.timestamp + expectedDurationInSecs;
         // sanity check:
         assert(expectedLockedUntil > Math.floor(Date.now() / 1000));
@@ -503,7 +490,7 @@ contract("Lock", accounts => {
             lockedUntil,
             perTermInterest,
             durationInSecs,
-            isActive
+            isActive,
         ] = newestLock;
         assert(lockId.toNumber() === expectedLockId);
         assert(amountLocked.toNumber() === amountToLock);
@@ -514,13 +501,13 @@ contract("Lock", accounts => {
         assert(isActive.toNumber() === 1);
     });
 
-    it("should allow to list an account's locks (non-zero offset)", async function() {
+    it("should allow to list an account's locks (non-zero offset)", async function () {
         const amountToLock = 1000;
 
         // lock funds, and get the product that was used:
         const [product] = await Promise.all([
             lockerInstance.lockProducts(0),
-            augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, { from: tokenHolder })
+            augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, { from: tokenHolder }),
         ]);
 
         const expectedPerTermInterest = product[0].toNumber();
@@ -532,49 +519,43 @@ contract("Lock", accounts => {
         const accountLocks = await lockerInstance.getLocksForAddress(tokenHolder, expectedAccountLockIndex, CHUNK_SIZE);
 
         assert.isArray(accountLocks);
-        assert(accountLocks.length <= CHUNK_SIZE);
+        assert(accountLocks.length <= CHUNK_SIZE, "number of owner's locks returned");
 
         const lock = accountLocks[0];
 
         // each lock should be a 7 element array
         assert.isArray(lock);
-        assert(lock.length === 7);
+        assert.equal(lock.length, 7, "locks array length");
 
         const expectedLockId = (await lockerInstance.getLockCount()) - 1;
 
         const expectedLock = await lockerInstance.locks(expectedLockId);
-        const [
-            expectedAmountLocked,
-            expectedOwner,
-            expectedProductId,
-            expectedLockedUntil,
-            expectedIsActive
-        ] = expectedLock;
 
         // the locks should be [ owner, amountLocked, interestEarned, lockedUntil, perTermInterest, durationInSecs, isActive ]
         const [lockId, amountLocked, interestEarned, lockedUntil, perTermInterest, durationInSecs, isActive] = lock;
-        assert(lockId.toNumber() === expectedLockId);
-        assert(expectedOwner === tokenHolder);
-        assert(expectedProductId.toNumber() === 0);
-        assert(amountLocked.toNumber() === expectedAmountLocked.toNumber());
-        assert(interestEarned.toNumber() === expectedInterestEarned);
-        assert(lockedUntil.toNumber() === expectedLockedUntil.toNumber());
-        assert(perTermInterest.toNumber() === expectedPerTermInterest);
-        assert(durationInSecs.toNumber() === expectedDurationInSecs);
-        assert(!!isActive.toNumber() === expectedIsActive);
+
+        assert.equal(lockId.toNumber(), expectedLockId, "lockId");
+        assert.equal(expectedLock.owner, tokenHolder, "owner");
+        assert.equal(expectedLock.productId.toNumber(), 0, "productId");
+        assert.equal(amountLocked.toNumber(), expectedLock.amountLocked.toNumber(), "amountLocked");
+        assert.equal(interestEarned.toNumber(), expectedInterestEarned, "interestEarned");
+        assert.equal(lockedUntil.toNumber(), expectedLock.lockedUntil.toNumber(), "lockedUntil");
+        assert.equal(perTermInterest.toNumber(), expectedPerTermInterest, "perTermInterest");
+        assert.equal(durationInSecs.toNumber(), expectedDurationInSecs, "durationInSecs");
+        assert.equal(isActive, expectedLock.isActive, "isActive");
     });
 
     it("should allow to list an account's locks when it has more than CHUNK_SIZE locks");
 
-    it("should prevent someone from locking more tokens than they have", async function() {
+    it("should prevent someone from locking more tokens than they have", async function () {
         const [startingBalances, totalLockAmountBefore, startingNumLocks] = await Promise.all([
             tokenTestHelpers.getAllBalances({
                 tokenHolder: tokenHolder,
                 lockerInstance: lockerInstance.address,
-                interestEarned: interestEarnedAddress
+                interestEarned: interestEarnedAddress,
             }),
             monetarySupervisor.totalLockedAmount(),
-            lockerInstance.getLockCountForAddress(tokenHolder)
+            lockerInstance.getLockCountForAddress(tokenHolder),
         ]);
 
         const amountToLock = startingBalances.tokenHolder.ace + 1000;
@@ -590,8 +571,8 @@ contract("Lock", accounts => {
             tokenTestHelpers.assertBalances(startingBalances, {
                 tokenHolder: { ace: startingBalances.tokenHolder.ace, gasFee: LOCK_MAX_GAS * testHelpers.GAS_PRICE },
                 lockerInstance: { ace: startingBalances.lockerInstance.ace },
-                interestEarned: { ace: startingBalances.interestEarned.ace }
-            })
+                interestEarned: { ace: startingBalances.interestEarned.ace },
+            }),
         ]);
 
         assert.equal(
@@ -603,7 +584,7 @@ contract("Lock", accounts => {
         assert.equal(finishingNumLocks.toNumber(), startingNumLocks.toNumber(), "number of locks shouldn't change");
     });
 
-    it("should prevent someone from depleting the interestEarnedAccount via locking", async function() {
+    it("should prevent someone from depleting the interestEarnedAccount via locking", async function () {
         // create lock product with 100% per term interest:
         await lockerInstance.addLockProduct(1000000, 120, 0, true);
         const newLockProductId = (await lockerInstance.getLockProductCount()).toNumber() - 1;
@@ -612,13 +593,13 @@ contract("Lock", accounts => {
             tokenTestHelpers.getAllBalances({
                 tokenHolder: tokenHolder,
                 lockerInstance: lockerInstance.address,
-                interestEarned: interestEarnedAddress
+                interestEarned: interestEarnedAddress,
             }),
             monetarySupervisor.totalLockedAmount(),
-            lockerInstance.getLockCountForAddress(tokenHolder)
+            lockerInstance.getLockCountForAddress(tokenHolder),
         ]);
 
-        const amountToLock = startingBalances.interestEarned.ace.add(1);
+        const amountToLock = startingBalances.interestEarned.ace.add(new BN(1));
 
         // this is less a test for the code, a more a sanity check for the test
         // (so that the lockFunds doesn't fail due to tokenHolder having insufficient funds):
@@ -627,7 +608,7 @@ contract("Lock", accounts => {
 
         await testHelpers.expectThrow(
             augmintToken.transferAndNotify(lockerInstance.address, amountToLock, newLockProductId, {
-                from: tokenHolder
+                from: tokenHolder,
             })
         );
         await testHelpers.assertNoEvents(lockerInstance, "NewLock");
@@ -638,8 +619,8 @@ contract("Lock", accounts => {
             tokenTestHelpers.assertBalances(startingBalances, {
                 tokenHolder: { ace: startingBalances.tokenHolder.ace, gasFee: LOCK_MAX_GAS * testHelpers.GAS_PRICE },
                 lockerInstance: { ace: startingBalances.lockerInstance.ace },
-                interestEarned: { ace: startingBalances.interestEarned.ace }
-            })
+                interestEarned: { ace: startingBalances.interestEarned.ace },
+            }),
         ]);
 
         assert.equal(
@@ -651,7 +632,7 @@ contract("Lock", accounts => {
         assert.equal(finishingNumLocks.toNumber(), startingNumLocks.toNumber(), "number of locks shouldn't change");
     });
 
-    it("should prevent someone from locking less than the minimumLockAmount", async function() {
+    it("should prevent someone from locking less than the minimumLockAmount", async function () {
         const minimumLockAmount = 1000;
 
         // create lock product with token minimum:
@@ -662,20 +643,20 @@ contract("Lock", accounts => {
         // can't lock less than the minimumLockAmount:
         await testHelpers.expectThrow(
             augmintToken.transferAndNotify(lockerInstance.address, minimumLockAmount - 1, newLockProductId, {
-                from: tokenHolder
+                from: tokenHolder,
             })
         );
     });
 
-    it("should allow someone to lock exactly the minimum", async function() {
+    it("should allow someone to lock exactly the minimum", async function () {
         const [startingBalances, totalLockAmountBefore, startingNumLocks] = await Promise.all([
             tokenTestHelpers.getAllBalances({
                 tokenHolder: tokenHolder,
                 lockerInstance: lockerInstance.address,
-                interestEarned: interestEarnedAddress
+                interestEarned: interestEarnedAddress,
             }),
             monetarySupervisor.totalLockedAmount(),
-            lockerInstance.getLockCountForAddress(tokenHolder)
+            lockerInstance.getLockCountForAddress(tokenHolder),
         ]);
 
         const minimumLockAmount = 1000;
@@ -685,7 +666,7 @@ contract("Lock", accounts => {
         const newLockProductId = (await lockerInstance.getLockProductCount()).toNumber() - 1;
 
         const tx = await augmintToken.transferAndNotify(lockerInstance.address, minimumLockAmount, newLockProductId, {
-            from: tokenHolder
+            from: tokenHolder,
         });
         testHelpers.logGasUse(this, tx, "transferAndNotify - lockFunds");
 
@@ -693,12 +674,12 @@ contract("Lock", accounts => {
 
         const eventResults = await testHelpers.assertEvent(lockerInstance, "NewLock", {
             lockOwner: tokenHolder,
-            lockId: expectedLockId,
-            amountLocked: minimumLockAmount,
-            interestEarned: x => x,
-            lockedUntil: x => x,
-            perTermInterest: x => x,
-            durationInSecs: x => x
+            lockId: expectedLockId.toString(),
+            amountLocked: minimumLockAmount.toString(),
+            interestEarned: (x) => x,
+            lockedUntil: (x) => x,
+            perTermInterest: (x) => x,
+            durationInSecs: (x) => x,
         });
 
         const [totalLockAmountAfter, finishingNumLocks] = await Promise.all([
@@ -708,34 +689,36 @@ contract("Lock", accounts => {
 
             tokenTestHelpers.assertBalances(startingBalances, {
                 tokenHolder: {
-                    ace: startingBalances.tokenHolder.ace.sub(minimumLockAmount),
-                    gasFee: LOCK_MAX_GAS * testHelpers.GAS_PRICE
+                    ace: startingBalances.tokenHolder.ace.sub(new BN(minimumLockAmount)),
+                    gasFee: LOCK_MAX_GAS * testHelpers.GAS_PRICE,
                 },
                 lockerInstance: {
-                    ace: startingBalances.lockerInstance.ace.add(minimumLockAmount).add(eventResults.interestEarned)
+                    ace: startingBalances.lockerInstance.ace
+                        .add(new BN(minimumLockAmount))
+                        .add(new BN(eventResults.interestEarned)),
                 },
-                interestEarned: { ace: startingBalances.interestEarned.ace.sub(eventResults.interestEarned) }
-            })
+                interestEarned: { ace: startingBalances.interestEarned.ace.sub(new BN(eventResults.interestEarned)) },
+            }),
         ]);
 
         assert.equal(
             totalLockAmountAfter.toString(),
-            totalLockAmountBefore.add(minimumLockAmount).toString(),
+            totalLockAmountBefore.add(new BN(minimumLockAmount)).toString(),
             "totalLockedAmount should be increased by locked amount "
         );
 
         assert.equal(finishingNumLocks.toNumber(), startingNumLocks.toNumber() + 1, "number of locks should be +1");
     });
 
-    it("should prevent someone from releasing a lock early", async function() {
+    it("should prevent someone from releasing a lock early", async function () {
         const amountToLock = 1000;
         const [startingBalances, totalLockAmountBefore] = await Promise.all([
             tokenTestHelpers.getAllBalances({
                 tokenHolder: tokenHolder,
                 lockerInstance: lockerInstance.address,
-                interestEarned: interestEarnedAddress
+                interestEarned: interestEarnedAddress,
             }),
-            monetarySupervisor.totalLockedAmount()
+            monetarySupervisor.totalLockedAmount(),
         ]);
 
         // lock funds, and get the product that was used:
@@ -743,8 +726,8 @@ contract("Lock", accounts => {
             lockerInstance.lockProducts(0),
 
             augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, {
-                from: tokenHolder
-            })
+                from: tokenHolder,
+            }),
         ]);
         testHelpers.logGasUse(this, lockFundsTx, "transferAndNotify - lockFunds");
 
@@ -762,30 +745,30 @@ contract("Lock", accounts => {
 
             tokenTestHelpers.assertBalances(startingBalances, {
                 tokenHolder: {
-                    ace: startingBalances.tokenHolder.ace.sub(amountToLock),
-                    gasFee: LOCK_MAX_GAS * testHelpers.GAS_PRICE
+                    ace: startingBalances.tokenHolder.ace.sub(new BN(amountToLock)),
+                    gasFee: LOCK_MAX_GAS * testHelpers.GAS_PRICE,
                 },
-                lockerInstance: { ace: startingBalances.lockerInstance.ace.add(amountToLock + interestEarned) },
-                interestEarned: { ace: startingBalances.interestEarned.ace.sub(interestEarned) }
-            })
+                lockerInstance: { ace: startingBalances.lockerInstance.ace.add(new BN(amountToLock + interestEarned)) },
+                interestEarned: { ace: startingBalances.interestEarned.ace.sub(new BN(interestEarned)) },
+            }),
         ]);
 
         assert.equal(
             totalLockAmountAfter.toString(),
-            totalLockAmountBefore.add(amountToLock).toString(),
+            totalLockAmountBefore.add(new BN(amountToLock)).toString(),
             "totalLockedAmount should be increased by locked amount "
         );
     });
 
-    it("should prevent someone from unlocking an unlocked lock", async function() {
+    it("should prevent someone from unlocking an unlocked lock", async function () {
         const [startingBalances, totalLockAmountBefore, startingNumLocks] = await Promise.all([
             tokenTestHelpers.getAllBalances({
                 tokenHolder: tokenHolder,
                 lockerInstance: lockerInstance.address,
-                interestEarned: interestEarnedAddress
+                interestEarned: interestEarnedAddress,
             }),
             monetarySupervisor.totalLockedAmount(),
-            lockerInstance.getLockCountForAddress(tokenHolder)
+            lockerInstance.getLockCountForAddress(tokenHolder),
         ]);
         const amountToLock = 1000;
 
@@ -800,7 +783,7 @@ contract("Lock", accounts => {
             amountToLock,
             newLockProductId,
             {
-                from: tokenHolder
+                from: tokenHolder,
             }
         );
         testHelpers.logGasUse(this, lockFundsTx, "transferAndNotify - lockFunds");
@@ -822,14 +805,14 @@ contract("Lock", accounts => {
 
             tokenTestHelpers.assertBalances(startingBalances, {
                 tokenHolder: {
-                    ace: startingBalances.tokenHolder.ace.add(interestEarned),
-                    gasFee: LOCK_MAX_GAS * testHelpers.GAS_PRICE + RELEASE_MAX_GAS * testHelpers.GAS_PRICE
+                    ace: startingBalances.tokenHolder.ace.add(new BN(interestEarned)),
+                    gasFee: LOCK_MAX_GAS * testHelpers.GAS_PRICE + RELEASE_MAX_GAS * testHelpers.GAS_PRICE,
                 },
                 lockerInstance: {
-                    ace: startingBalances.lockerInstance.ace
+                    ace: startingBalances.lockerInstance.ace,
                 },
-                interestEarned: { ace: startingBalances.interestEarned.ace.sub(interestEarned) }
-            })
+                interestEarned: { ace: startingBalances.interestEarned.ace.sub(new BN(interestEarned)) },
+            }),
         ]);
 
         assert.equal(
@@ -845,53 +828,53 @@ contract("Lock", accounts => {
         );
     });
 
-    it("should only allow whitelisted lock contract to be used", async function() {
+    it("should only allow whitelisted lock contract to be used", async function () {
         const craftedLocker = await Locker.new(accounts[0], augmintToken.address, monetarySupervisor.address);
-        await craftedLocker.grantPermission(accounts[0], "StabilityBoard");
+        await craftedLocker.grantPermission(accounts[0], web3.utils.asciiToHex("StabilityBoard"));
         await craftedLocker.addLockProduct(1000000, 120, 0, true);
         const newLockProductId = (await craftedLocker.getLockProductCount()).toNumber() - 1;
         await testHelpers.expectThrow(
             augmintToken.transferAndNotify(craftedLocker.address, 10000, newLockProductId, {
-                from: tokenHolder
+                from: tokenHolder,
             })
         );
     });
 
-    it("should only allow the token contract to call transferNotification", async function() {
+    it("should only allow the token contract to call transferNotification", async function () {
         await testHelpers.expectThrow(lockerInstance.transferNotification(accounts[0], 1000, 0, { from: accounts[0] }));
     });
 
-    it("only allowed contract should call requestInterest ", async function() {
+    it("only allowed contract should call requestInterest ", async function () {
         const interestAmount = 100;
         // make sure it's not reverting b/c not enough interest
         assert((await augmintToken.balanceOf(interestEarnedAddress)).gte(interestAmount));
         await testHelpers.expectThrow(monetarySupervisor.requestInterest(1000, interestAmount, { from: accounts[0] }));
     });
 
-    it("only allowed contract should call releaseFundsNotification ", async function() {
+    it("only allowed contract should call releaseFundsNotification ", async function () {
         const amountToLock = 10000;
         const lockFundsTx = await augmintToken.transferAndNotify(lockerInstance.address, amountToLock, 0, {
-            from: tokenHolder
+            from: tokenHolder,
         });
         testHelpers.logGasUse(this, lockFundsTx, "transferAndNotify - lockFunds");
 
         await testHelpers.expectThrow(monetarySupervisor.releaseFundsNotification(amountToLock, { from: accounts[0] }));
     });
 
-    it("Should allow to change  monetarySupervisor contract", async function() {
+    it("Should allow to change  monetarySupervisor contract", async function () {
         const newMonetarySupervisor = monetarySupervisor.address;
         const tx = await lockerInstance.setMonetarySupervisor(newMonetarySupervisor);
         testHelpers.logGasUse(this, tx, "setSystemContracts");
 
         const [actualMonetarySupervisor] = await Promise.all([
             lockerInstance.monetarySupervisor(),
-            testHelpers.assertEvent(lockerInstance, "MonetarySupervisorChanged", { newMonetarySupervisor })
+            testHelpers.assertEvent(lockerInstance, "MonetarySupervisorChanged", { newMonetarySupervisor }),
         ]);
 
         assert.equal(actualMonetarySupervisor, newMonetarySupervisor);
     });
 
-    it("Only allowed should change rates and monetarySupervisor contracts", async function() {
+    it("Only allowed should change rates and monetarySupervisor contracts", async function () {
         const newMonetarySupervisor = monetarySupervisor.address;
         await testHelpers.expectThrow(
             lockerInstance.setMonetarySupervisor(newMonetarySupervisor, { from: accounts[1] })

--- a/test/preToken.js
+++ b/test/preToken.js
@@ -1,41 +1,45 @@
 const PreToken = artifacts.require("./PreToken.sol");
 const testHelpers = require("./helpers/testHelpers.js");
 
+const BN = web3.utils.BN;
+
 let preToken;
 let testAgreement; // used for test failing
 
 function parseAgreement(agreementArray) {
-    return agreementArray.filter(agreementTuple => !agreementTuple[1].eq(0)).map(tuple => {
-        return {
-            id: tuple[0].toNumber(),
-            owner: "0x" + tuple[1].toString(16).padStart(40, "0"),
-            balance: tuple[2].toNumber(),
-            hash: "0x" + tuple[3].toString(16).padStart(64, "0"),
-            discount: tuple[4].toNumber(),
-            cap: tuple[5].toNumber()
-        };
-    });
+    return agreementArray
+        .filter((agreementTuple) => !agreementTuple[1].eq(0))
+        .map((tuple) => {
+            return {
+                id: tuple[0].toNumber(),
+                owner: "0x" + tuple[1].toString(16).padStart(40, "0"),
+                balance: tuple[2].toNumber(),
+                hash: "0x" + tuple[3].toString(16).padStart(64, "0"),
+                discount: tuple[4].toNumber(),
+                cap: tuple[5].toNumber(),
+            };
+        });
 }
 
-contract("PreToken", accounts => {
+contract("PreToken", (accounts) => {
     before(async () => {
-        preToken = PreToken.at(PreToken.address);
+        preToken = await PreToken.at(PreToken.address);
 
         testAgreement = {
             owner: accounts[8],
             hash: "0x0000000000000000000000000000000000000000000000000000000000000008",
             discount: 800000,
-            cap: 20000000
+            cap: 20000000,
         };
         await preToken.addAgreement(testAgreement.owner, testAgreement.hash, testAgreement.discount, testAgreement.cap);
     });
 
-    it("should add an agreement", async function() {
+    it("should add an agreement", async function () {
         const agreement = {
             owner: accounts[3],
             hash: "0x0000000000000000000000000000000000000000000000000000000000000001",
             discount: 800000,
-            cap: 20000000
+            cap: 20000000,
         };
 
         const agreementsCountBefore = (await preToken.getAgreementsCount()).toNumber();
@@ -47,50 +51,50 @@ contract("PreToken", accounts => {
             agreementsCountAfter,
             actualAgreementArray,
             actualAgreementOwnerHash,
-            actualAgreementGetter
+            actualAgreementGetter,
         ] = await Promise.all([
-            preToken.getAgreementsCount().then(res => res.toNumber()),
+            preToken.getAgreementsCount().then((res) => res.toNumber()),
             preToken.agreements(agreement.hash),
             preToken.agreementOwners(agreement.owner),
             preToken.getAgreements(agreementsCountBefore, 1),
             testHelpers.assertEvent(preToken, "NewAgreement", {
                 owner: agreement.owner,
                 agreementHash: agreement.hash,
-                discount: agreement.discount,
-                valuationCap: agreement.cap
-            })
+                discount: agreement.discount.toString(),
+                valuationCap: agreement.cap.toString(),
+            }),
         ]);
         const parsedAgreement = parseAgreement(actualAgreementGetter)[0];
 
         assert.equal(agreementsCountAfter, agreementsCountBefore + 1);
 
         assert.equal(parsedAgreement.id, agreementsCountBefore);
-        assert.equal(parsedAgreement.owner, agreement.owner);
+        assert.equal(parsedAgreement.owner, agreement.owner.toLowerCase(), "Agreement owner shoud be set (via getter)");
         assert.equal(parsedAgreement.hash, agreement.hash);
-        assert.equal(parsedAgreement.discount, agreement.discount);
+        assert.equal(parsedAgreement.discount, agreement.discount.toString());
         assert.equal(parsedAgreement.cap, agreement.cap);
 
         assert.equal(actualAgreementOwnerHash, agreement.hash);
 
-        assert.equal(actualAgreementArray[0].toString(), agreement.owner);
+        assert.equal(actualAgreementArray[0], agreement.owner, "Agreement owner shoud be set in contract array");
         assert.equal(actualAgreementArray[1].toString(), "0");
         assert.equal(actualAgreementArray[2].toNumber(), agreement.discount);
         assert.equal(actualAgreementArray[3].toNumber(), agreement.cap);
     });
 
-    it("Should list agreements", async function() {
+    it("Should list agreements", async function () {
         const agreement1 = {
             owner: accounts[4],
             hash: "0x0000000000000000000000000000000000000000000000000000000000000002",
             discount: 800000,
-            cap: 20000000
+            cap: 20000000,
         };
 
         const agreement2 = {
             owner: accounts[5],
             hash: "0x0000000000000000000000000000000000000000000000000000000000000003",
             discount: 900000,
-            cap: 25000000
+            cap: 25000000,
         };
 
         const agreementsCountBefore = (await preToken.getAgreementsCount()).toNumber();
@@ -101,23 +105,23 @@ contract("PreToken", accounts => {
         await testHelpers.assertEvent(preToken, "NewAgreement", {
             owner: agreement1.owner,
             agreementHash: agreement1.hash,
-            discount: agreement1.discount,
-            valuationCap: agreement1.cap
+            discount: agreement1.discount.toString(),
+            valuationCap: agreement1.cap.toString(),
         });
 
         const tx2 = await preToken.addAgreement(agreement2.owner, agreement2.hash, agreement2.discount, agreement2.cap);
         testHelpers.logGasUse(this, tx2, "addAgreement");
 
         const [agreementsCountAfter, agreementsAfter] = await Promise.all([
-            preToken.getAgreementsCount().then(res => res.toNumber()),
+            preToken.getAgreementsCount().then((res) => res.toNumber()),
 
             preToken.getAgreements(agreementsCountBefore, 2),
             testHelpers.assertEvent(preToken, "NewAgreement", {
                 owner: agreement2.owner,
                 agreementHash: agreement2.hash,
-                discount: agreement2.discount,
-                valuationCap: agreement2.cap
-            })
+                discount: agreement2.discount.toString(),
+                valuationCap: agreement2.cap.toString(),
+            }),
         ]);
 
         const parsedAgreements = parseAgreement(agreementsAfter);
@@ -125,24 +129,24 @@ contract("PreToken", accounts => {
         assert.equal(agreementsCountAfter, agreementsCountBefore + 2);
 
         assert.equal(parsedAgreements[0].id, agreementsCountBefore);
-        assert.equal(parsedAgreements[0].owner, agreement1.owner);
+        assert.equal(parsedAgreements[0].owner, agreement1.owner.toLowerCase(), "Owner 1 should be set");
         assert.equal(parsedAgreements[0].hash, agreement1.hash);
-        assert.equal(parsedAgreements[0].discount, agreement1.discount);
-        assert.equal(parsedAgreements[0].cap, agreement1.cap);
+        assert.equal(parsedAgreements[0].discount, agreement1.discount.toString());
+        assert.equal(parsedAgreements[0].cap, agreement1.cap.toString());
 
         assert.equal(parsedAgreements[1].id, agreementsCountBefore + 1);
-        assert.equal(parsedAgreements[1].owner, agreement2.owner);
+        assert.equal(parsedAgreements[1].owner, agreement2.owner.toLowerCase(), "Owner 2 should be set");
         assert.equal(parsedAgreements[1].hash, agreement2.hash);
-        assert.equal(parsedAgreements[1].discount, agreement2.discount);
-        assert.equal(parsedAgreements[1].cap, agreement2.cap);
+        assert.equal(parsedAgreements[1].discount, agreement2.discount.toString());
+        assert.equal(parsedAgreements[1].cap, agreement2.cap.toString());
     });
 
-    it("should NOT add an agreement to 0x0 account", async function() {
+    it("should NOT add an agreement to 0x0 account", async function () {
         const agreement = {
             owner: "0x0000000000000000000000000000000000000000",
             hash: "0x0000000000000000000000000000000000000000000000000000000000000004",
             discount: 800000,
-            cap: 20000000
+            cap: 20000000,
         };
 
         await testHelpers.expectThrow(
@@ -150,12 +154,12 @@ contract("PreToken", accounts => {
         );
     });
 
-    it("should NOT add an agreement with 0 discount", async function() {
+    it("should NOT add an agreement with 0 discount", async function () {
         const agreement = {
             owner: accounts[6],
             hash: "0x0000000000000000000000000000000000000000000000000000000000000005",
             discount: 0,
-            cap: 20000000
+            cap: 20000000,
         };
 
         await testHelpers.expectThrow(
@@ -163,12 +167,12 @@ contract("PreToken", accounts => {
         );
     });
 
-    it("should NOT add an agreement without agreementHash", async function() {
+    it("should NOT add an agreement without agreementHash", async function () {
         const agreement = {
             owner: accounts[6],
             hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
             discount: 800000,
-            cap: 20000000
+            cap: 20000000,
         };
 
         await testHelpers.expectThrow(
@@ -176,12 +180,12 @@ contract("PreToken", accounts => {
         );
     });
 
-    it("should NOT add an agreement if owner already has one", async function() {
+    it("should NOT add an agreement if owner already has one", async function () {
         const agreement = {
             owner: accounts[6],
             hash: "0x0000000000000000000000000000000000000000000000000000000000000006",
             discount: 800000,
-            cap: 20000000
+            cap: 20000000,
         };
         const tx = await preToken.addAgreement(agreement.owner, agreement.hash, agreement.discount, agreement.cap);
         testHelpers.logGasUse(this, tx, "addAgreement");
@@ -191,22 +195,22 @@ contract("PreToken", accounts => {
         );
     });
 
-    it("add agreement should be only via multiSig", async function() {
+    it("add agreement should be only via multiSig", async function () {
         const agreement = {
             owner: accounts[7],
             hash: "0x0000000000000000000000000000000000000000000000000000000000000007",
             discount: 800000,
-            cap: 20000000
+            cap: 20000000,
         };
         await testHelpers.expectThrow(
             preToken.addAgreement(agreement.owner, agreement.hash, agreement.discount, agreement.cap, {
-                from: accounts[1]
+                from: accounts[1],
             })
         );
     });
 
-    it("should issueTo an account with agreement", async function() {
-        const amount = 1000;
+    it("should issueTo an account with agreement", async function () {
+        const amount = new BN(1000);
         const supplyBefore = await preToken.totalSupply();
 
         const tx = await preToken.issueTo(testAgreement.hash, amount);
@@ -218,29 +222,29 @@ contract("PreToken", accounts => {
             testHelpers.assertEvent(preToken, "Transfer", {
                 from: "0x0000000000000000000000000000000000000000",
                 to: testAgreement.owner,
-                amount
-            })
+                amount: amount.toString(),
+            }),
         ]);
 
         assert.equal(supplyAfter.toString(), supplyBefore.add(amount).toString());
         assert.equal(balanceAfter.toString(), amount.toString());
     });
 
-    it("should NOT issueTo a non existing agreement", async function() {
+    it("should NOT issueTo a non existing agreement", async function () {
         await testHelpers.expectThrow(
             preToken.issueTo("0x0000000000000000000000000000000000000000000000000000000000000007", 1000)
         );
     });
 
-    it("only permitted should call issueTo", async function() {
+    it("only permitted should call issueTo", async function () {
         await testHelpers.expectThrow(preToken.issueTo(testAgreement.owner, 1000, { from: accounts[1] }));
     });
 
-    it("should burnFrom an account with agreement", async function() {
-        const amount = 100;
+    it("should burnFrom an account with agreement", async function () {
+        const amount = new BN(100);
         const [supplyBefore, balanceBefore] = await Promise.all([
             preToken.totalSupply(),
-            preToken.balanceOf(testAgreement.owner)
+            preToken.balanceOf(testAgreement.owner),
         ]);
 
         const tx = await preToken.burnFrom(testAgreement.hash, amount);
@@ -252,25 +256,25 @@ contract("PreToken", accounts => {
             testHelpers.assertEvent(preToken, "Transfer", {
                 to: "0x0000000000000000000000000000000000000000",
                 from: testAgreement.owner,
-                amount
-            })
+                amount: amount.toString(),
+            }),
         ]);
 
         assert.equal(supplyAfter.toString(), supplyBefore.sub(amount).toString());
         assert.equal(balanceAfter.toString(), balanceBefore.sub(amount).toString());
     });
 
-    it("shouldn't burnFrom more than balance", async function() {
+    it("shouldn't burnFrom more than balance", async function () {
         const balanceBefore = await preToken.balanceOf(testAgreement.owner);
 
-        await testHelpers.expectThrow(preToken.burnFrom(testAgreement.hash, balanceBefore.add(1)));
+        await testHelpers.expectThrow(preToken.burnFrom(testAgreement.hash, balanceBefore.add(new BN(1))));
     });
 
-    it("shouldn't burnFrom 0 amount", async function() {
+    it("shouldn't burnFrom 0 amount", async function () {
         await testHelpers.expectThrow(preToken.burnFrom(testAgreement.hash, 0));
     });
 
-    it("only allowed should burnFrom", async function() {
+    it("only allowed should burnFrom", async function () {
         await testHelpers.expectThrow(preToken.burnFrom(testAgreement.hash, 1, { from: accounts[1] }));
     });
 });

--- a/test/preTokenTransfer.js
+++ b/test/preTokenTransfer.js
@@ -1,34 +1,36 @@
 const PreToken = artifacts.require("./PreToken.sol");
 const testHelpers = require("./helpers/testHelpers.js");
 
+const BN = web3.utils.BN;
+
 let preToken;
 let agreement;
 let snapshotId;
-const initialIssue = 1000000;
+const initialIssue = new BN(1000000);
 
-contract("PreToken transfer", accounts => {
+contract("PreToken transfer", (accounts) => {
     before(async () => {
-        preToken = PreToken.at(PreToken.address);
+        preToken = await PreToken.at(PreToken.address);
         agreement = {
             owner: accounts[3],
             hash: "0x36517e28afd52e6a9fc53d6922833c67b02e339943d737f1abefa877ff69b68a",
             discount: 700000,
-            cap: 15000000
+            cap: 15000000,
         };
         await preToken.addAgreement(agreement.owner, agreement.hash, agreement.discount, agreement.cap);
 
         await preToken.issueTo(agreement.hash, initialIssue);
     });
 
-    beforeEach(async function() {
+    beforeEach(async function () {
         snapshotId = await testHelpers.takeSnapshot();
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
         await testHelpers.revertSnapshot(snapshotId);
     });
 
-    it("should transfer to an account which has no agreement yet", async function() {
+    it("should transfer to an account which has no agreement yet", async function () {
         const to = accounts[4];
         const supplyBefore = await preToken.totalSupply();
 
@@ -41,7 +43,7 @@ contract("PreToken transfer", accounts => {
             fromAgreementOwnerHashAfter,
             toAgreementOwnerHashAfter,
             fromBalAfter,
-            toBalAfter
+            toBalAfter,
         ] = await Promise.all([
             preToken.totalSupply(),
             preToken.agreements(agreement.hash),
@@ -49,35 +51,39 @@ contract("PreToken transfer", accounts => {
             preToken.agreementOwners(to),
             preToken.balanceOf(agreement.owner),
             preToken.balanceOf(to),
-            testHelpers.assertEvent(preToken, "Transfer", { from: agreement.owner, to, amount: initialIssue })
+            testHelpers.assertEvent(preToken, "Transfer", {
+                from: agreement.owner,
+                to,
+                amount: initialIssue.toString(),
+            }),
         ]);
 
-        assert.equal(supplyAfter.toString(), supplyBefore.toString());
-        assert.equal(toBalAfter.toNumber(), initialIssue);
+        assert.equal(supplyAfter.toString(), supplyBefore.toString(), "Total supply should NOT change");
+        assert.equal(toBalAfter.toString(), initialIssue.toString(), "Recevier balance should update");
         assert.equal(fromBalAfter.toString(), "0");
 
         assert.equal(fromAgreementOwnerHashAfter, "0x0000000000000000000000000000000000000000000000000000000000000000");
         assert.equal(toAgreementOwnerHashAfter, agreement.hash);
 
         assert.equal(agreementAfter[0], to);
-        assert.equal(agreementAfter[1].toNumber(), initialIssue);
+        assert.equal(agreementAfter[1].toString(), initialIssue.toString());
         assert.equal(agreementAfter[2].toNumber(), agreement.discount);
         assert.equal(agreementAfter[3].toNumber(), agreement.cap);
     });
 
-    it("should NOT transfer 0 amount", async function() {
+    it("should NOT transfer 0 amount", async function () {
         const to = accounts[4];
         const amount = 0;
 
         await testHelpers.expectThrow(preToken.transfer(to, amount, { from: agreement.owner }));
     });
 
-    it("should NOT transfer to an account which has an agreement", async function() {
+    it("should NOT transfer to an account which has an agreement", async function () {
         const agreement2 = {
             owner: accounts[4],
             hash: "0x66517e28afd52e6a9fc53d6922833c67b02e339943d737f1abefa877ff69b68a",
             discount: 700000,
-            cap: 15000000
+            cap: 15000000,
         };
 
         await preToken.addAgreement(agreement2.owner, agreement2.hash, agreement2.discount, agreement2.cap);
@@ -85,31 +91,31 @@ contract("PreToken transfer", accounts => {
         await testHelpers.expectThrow(preToken.transfer(agreement2.owner, initialIssue, { from: agreement.owner }));
     });
 
-    it("should NOT transfer less than balance", async function() {
+    it("should NOT transfer less than balance", async function () {
         const to = accounts[4];
-        const amount = initialIssue - 1;
+        const amount = initialIssue.sub(new BN(1));
         await testHelpers.expectThrow(preToken.transfer(to, amount, { from: agreement.owner }));
     });
 
-    it("should NOT transfer more than balance", async function() {
+    it("should NOT transfer more than balance", async function () {
         const to = accounts[4];
-        const amount = initialIssue + 1;
+        const amount = initialIssue.add(new BN(1));
         await testHelpers.expectThrow(preToken.transfer(to, amount, { from: agreement.owner }));
     });
 
-    it("should NOT transfer to 0x0", async function() {
-        const to = "0x0";
+    it("should NOT transfer to 0x0", async function () {
+        const to = "0x0000000000000000000000000000000000000000";
         await testHelpers.expectThrow(preToken.transfer(to, initialIssue, { from: agreement.owner }));
     });
 
-    it("should NOT transfer if has no agreement", async function() {
+    it("should NOT transfer if has no agreement", async function () {
         const to = accounts[5];
         const from = accounts[6];
         const amount = 0;
         await testHelpers.expectThrow(preToken.transfer(to, amount, { from }));
     });
 
-    it("should transferFrom", async function() {
+    it("should transferFrom", async function () {
         const to = accounts[4];
         const fromHash = agreement.hash;
         const supplyBefore = await preToken.totalSupply();
@@ -122,20 +128,24 @@ contract("PreToken transfer", accounts => {
             preToken.agreements(agreement.hash),
             preToken.balanceOf(agreement.owner),
             preToken.balanceOf(to),
-            testHelpers.assertEvent(preToken, "Transfer", { from: agreement.owner, to, amount: initialIssue })
+            testHelpers.assertEvent(preToken, "Transfer", {
+                from: agreement.owner,
+                to,
+                amount: initialIssue.toString(),
+            }),
         ]);
 
-        assert.equal(supplyAfter.toString(), supplyBefore.toString());
+        assert.equal(supplyAfter.toString(), supplyBefore.toString(), "Total supply should NOT change");
         assert.equal(ownerBalAfter.toNumber(), 0);
-        assert.equal(toBalAfter.toNumber(), initialIssue);
+        assert.equal(toBalAfter.toString(), initialIssue.toString(), "Recevier balance should update");
 
         assert.equal(agreementAfter[0], to);
-        assert.equal(agreementAfter[1].toNumber(), initialIssue);
+        assert.equal(agreementAfter[1].toString(), initialIssue.toString());
         assert.equal(agreementAfter[2].toNumber(), agreement.discount);
         assert.equal(agreementAfter[3].toNumber(), agreement.cap);
     });
 
-    it("only permitted should transferFrom", async function() {
+    it("only permitted should transferFrom", async function () {
         const to = accounts[4];
         const fromHash = agreement.owner;
 

--- a/test/restricted.js
+++ b/test/restricted.js
@@ -3,69 +3,73 @@
 */
 const testHelpers = require("./helpers/testHelpers.js");
 const tokenTestHelpers = require("./helpers/tokenTestHelpers.js");
+const PERM1 = web3.utils.asciiToHex("TESTPERMISSION1");
+const PERM2 = web3.utils.asciiToHex("TESTPERMISSION2");
 
 let augmintTokenInstance;
 
-contract("Restricted.sol tests", accounts => {
+contract("Restricted.sol tests", (accounts) => {
     before(async () => {
         augmintTokenInstance = tokenTestHelpers.augmintToken;
     });
 
-    it("only permitted should be able to grant permissions ", async function() {
+    it("only permitted should be able to grant permissions ", async function () {
         await testHelpers.expectThrow(
-            augmintTokenInstance.grantPermission(accounts[0], "TESTPERMISSION", { from: accounts[1] })
-        );
-    });
-
-    it("only permitted should be able to grant multiple permissions ", async function() {
-        await testHelpers.expectThrow(
-            augmintTokenInstance.grantMultiplePermissions(accounts[0], ["TESTPERMISSION1", "TESTPERMISSION2"], {
-                from: accounts[1]
+            augmintTokenInstance.grantPermission(accounts[0], PERM1, {
+                from: accounts[1],
             })
         );
     });
 
-    it("only permitted to revoke  permission ", async function() {
+    it("only permitted should be able to grant multiple permissions ", async function () {
         await testHelpers.expectThrow(
-            augmintTokenInstance.revokePermission(accounts[0], "TESTPERMISSION1", {
-                from: accounts[1]
+            augmintTokenInstance.grantMultiplePermissions(accounts[0], [PERM1, PERM2], {
+                from: accounts[1],
             })
         );
     });
 
-    it("should grant & revoke multiple permissions ", async function() {
-        const tx1 = await augmintTokenInstance.grantMultiplePermissions(accounts[0], ["perm1", "perm2"], {
-            from: accounts[0]
+    it("only permitted to revoke  permission ", async function () {
+        await testHelpers.expectThrow(
+            augmintTokenInstance.revokePermission(accounts[0], PERM1, {
+                from: accounts[1],
+            })
+        );
+    });
+
+    it("should grant & revoke multiple permissions ", async function () {
+        const tx1 = await augmintTokenInstance.grantMultiplePermissions(accounts[0], [PERM1, PERM2], {
+            from: accounts[0],
         });
         testHelpers.logGasUse(this, tx1, "grantMultiplePermissions");
 
         let perm1;
         let perm2;
         [perm1, perm2] = await Promise.all([
-            augmintTokenInstance.permissions(accounts[0], "perm1"),
-            augmintTokenInstance.permissions(accounts[0], "perm2")
+            augmintTokenInstance.permissions(accounts[0], PERM1),
+            augmintTokenInstance.permissions(accounts[0], PERM2),
         ]);
         assert.equal(perm1, true);
         assert.equal(perm2, true);
 
-        const tx2 = await augmintTokenInstance.revokeMultiplePermissions(accounts[0], ["perm1", "perm2"], {
-            from: accounts[0]
+        const tx2 = await augmintTokenInstance.revokeMultiplePermissions(accounts[0], [PERM1, PERM2], {
+            from: accounts[0],
         });
         testHelpers.logGasUse(this, tx2, "revokeMultiplePermissions");
 
         [perm1, perm2] = await Promise.all([
-            augmintTokenInstance.permissions(accounts[0], "perm1"),
-            augmintTokenInstance.permissions(accounts[0], "perm2")
+            augmintTokenInstance.permissions(accounts[0], PERM1),
+            augmintTokenInstance.permissions(accounts[0], PERM2),
         ]);
 
         assert.equal(perm1, false);
         assert.equal(perm2, false);
     });
 
-    it("only permitted to revoke multiple permissions ", async function() {
+    it("only permitted to revoke multiple permissions ", async function () {
         await testHelpers.expectThrow(
-            augmintTokenInstance.revokeMultiplePermissions(accounts[0], ["TESTPERMISSION1", "TESTPERMISSION2"], {
-                from: accounts[1]
+            augmintTokenInstance.revokeMultiplePermissions(accounts[0], [PERM1, PERM2], {
+                from: accounts[1],
             })
         );
     });

--- a/test/safeMath.js
+++ b/test/safeMath.js
@@ -2,41 +2,39 @@
 sub, div, rounded div covered by other test cases
 */
 
-const BigNumber = require("bignumber.js");
 const Locker = artifacts.require("./Locker.sol");
 const testHelpers = require("./helpers/testHelpers.js");
 const MonetarySupervisor = artifacts.require("./MonetarySupervisor.sol");
 const SafeMathTester = artifacts.require("./test/SafeMathTester.sol");
 
+const BN = web3.utils.BN;
+
 let locker;
 let monetarySupervisor;
 let safeMathTester;
-const MAX_UINT256 = new BigNumber(2).pow(256).sub(1);
+const MAX_UINT256 = new BN(2).pow(new BN(256)).sub(new BN(1));
 
 contract("SafeMath", () => {
-    before(() => {
-        locker = Locker.at(Locker.address);
-        monetarySupervisor = MonetarySupervisor.at(MonetarySupervisor.address);
-        safeMathTester = SafeMathTester.at(SafeMathTester.address);
+    before(async () => {
+        [locker, monetarySupervisor, safeMathTester] = await Promise.all([
+            Locker.deployed(),
+            MonetarySupervisor.deployed(),
+            SafeMathTester.deployed(),
+        ]);
     });
 
-    it("should throw if mul overflows", async function() {
+    it("should throw if mul overflows", async function () {
         await testHelpers.expectThrow(
-            locker.calculateInterest(
-                2,
-                MAX_UINT256.add(1)
-                    .div(2)
-                    .round(0, BigNumber.ROUND_UP)
-            )
+            locker.calculateInterest(2, MAX_UINT256.add(new BN(1)).div(new BN(2)).add(new BN(1)))
         );
     });
 
-    it("should throw if add overflows", async function() {
-        await monetarySupervisor.issueToReserve(1);
-        await testHelpers.expectThrow(monetarySupervisor.issueToReserve(MAX_UINT256.toString()));
+    it("should throw if add overflows", async function () {
+        await monetarySupervisor.issueToReserve(new BN(1));
+        await testHelpers.expectThrow(monetarySupervisor.issueToReserve(MAX_UINT256));
     });
 
-    it("should round up if not exactly divisible", async function() {
+    it("should round up if not exactly divisible", async function () {
         assert.equal(Number(await locker.calculateInterest(1000, 1000)), 1);
         assert.equal(Number(await locker.calculateInterest(1, 1000000)), 1);
         assert.equal(Number(await locker.calculateInterest(1000, 1001)), 2);
@@ -51,7 +49,7 @@ contract("SafeMath", () => {
         assert.equal(Number(await locker.calculateInterest(120000, 10000)), 1200);
     });
 
-    it("should round properly when using roundedDiv", async function() {
+    it("should round properly when using roundedDiv", async function () {
         assert.equal(Number(await safeMathTester.roundedDiv(0, 2)), 0);
         assert.equal(Number(await safeMathTester.roundedDiv(1, 2)), 1);
         assert.equal(Number(await safeMathTester.roundedDiv(2, 2)), 1);
@@ -74,13 +72,13 @@ contract("SafeMath", () => {
 
         assert.equal(Number(await safeMathTester.roundedDiv(MAX_UINT256, 1)), MAX_UINT256);
         assert.equal(Number(await safeMathTester.roundedDiv(MAX_UINT256, MAX_UINT256)), 1);
-        assert.equal(Number(await safeMathTester.roundedDiv(MAX_UINT256.sub(1), MAX_UINT256)), 1);
-        assert.equal(Number(await safeMathTester.roundedDiv(MAX_UINT256, MAX_UINT256.sub(1))), 1);
-        assert.equal(Number(await safeMathTester.roundedDiv(MAX_UINT256, MAX_UINT256.div(2))), 2);
-        assert.equal(Number(await safeMathTester.roundedDiv(MAX_UINT256, MAX_UINT256.div(3))), 3);
+        assert.equal(Number(await safeMathTester.roundedDiv(MAX_UINT256.sub(new BN(1)), MAX_UINT256)), 1);
+        assert.equal(Number(await safeMathTester.roundedDiv(MAX_UINT256, MAX_UINT256.sub(new BN(1)))), 1);
+        assert.equal(Number(await safeMathTester.roundedDiv(MAX_UINT256, MAX_UINT256.div(new BN(2)))), 2);
+        assert.equal(Number(await safeMathTester.roundedDiv(MAX_UINT256, MAX_UINT256.div(new BN(3)))), 3);
     });
 
-    it("should not divide by zero", async function() {
+    it("should not divide by zero", async function () {
         await testHelpers.expectThrow(safeMathTester.roundedDiv(0, 0));
         await testHelpers.expectThrow(safeMathTester.roundedDiv(1, 0));
         await testHelpers.expectThrow(safeMathTester.roundedDiv(MAX_UINT256, 0));

--- a/test/token.js
+++ b/test/token.js
@@ -7,52 +7,52 @@ const SB_setFeeAccount = artifacts.require("./scriptTests/SB_setFeeAccount.sol")
 let augmintToken;
 let stabilityBoardProxy;
 
-contract("AugmintToken tests", accounts => {
+contract("AugmintToken tests", (accounts) => {
     before(async () => {
         augmintToken = tokenTestHelpers.augmintToken;
-        stabilityBoardProxy = StabilityBoardProxy.at(StabilityBoardProxy.address);
+        stabilityBoardProxy = await StabilityBoardProxy.deployed();
     });
 
-    it("shouldn't create a token contract without feeAccount", async function() {
+    it("shouldn't create a token contract without feeAccount", async function () {
         await testHelpers.expectThrow(
             AugmintToken.new(
                 accounts[0],
                 "Augmint Euro", // name
-                "AEUR", // symbol
-                "EUR", // peggedSymbol
+                web3.utils.asciiToHex("AEUR"), // symbol
+                web3.utils.asciiToHex("EUR"), // peggedSymbol
                 2, // decimals
-                0 // feeaccount
+                "0x0000000000000000000000000000000000000000" // feeaccount
             )
         );
     });
 
-    it("shouldn't create a token contract without token name", async function() {
+    it("shouldn't create a token contract without token name", async function () {
         await testHelpers.expectThrow(
             AugmintToken.new(
                 accounts[0],
                 "", // name
-                "AEUR", // symbol
-                "EUR", // peggedSymbol
+                web3.utils.asciiToHex("AEUR"), // symbol
+                web3.utils.asciiToHex("EUR"), // peggedSymbol
                 2, // decimals
                 tokenTestHelpers.feeAccount.address
             )
         );
     });
 
-    it("shouldn't create a token contract without token symbol", async function() {
+    it("shouldn't create a token contract without token symbol", async function () {
         await testHelpers.expectThrow(
             AugmintToken.new(
                 accounts[0],
                 "Augmint Euro", // name
                 "", // symbol
-                "EUR", // peggedSymbol
+                web3.utils.asciiToHex("EUR"), // peggedSymbol
                 2, // decimals,
                 tokenTestHelpers.feeAccount.address
             )
         );
     });
 
-    it("should change feeAccount", async function() {
+    it("should change feeAccount", async function () {
         const newFeeAccount = accounts[2];
         const setFeeAccountScript = await SB_setFeeAccount.new(augmintToken.address, newFeeAccount);
 
@@ -64,24 +64,22 @@ contract("AugmintToken tests", accounts => {
         const [actualFeeAccount] = await Promise.all([
             augmintToken.feeAccount(),
             testHelpers.assertEvent(augmintToken, "FeeAccountChanged", {
-                newFeeAccount
-            })
+                newFeeAccount,
+            }),
         ]);
 
         assert.equal(actualFeeAccount, newFeeAccount);
     });
 
-    it("should not call setFeeAccount directly", async function() {
+    it("should not call setFeeAccount directly", async function () {
         const newFeeAccount = accounts[2];
         await testHelpers.expectThrow(augmintToken.setFeeAccount(newFeeAccount, { from: accounts[1] }));
     });
 
-    it("should change token name if caller has permission", async function() {
+    it("should change token name if caller has permission", async function () {
         const oldName = await augmintToken.name();
 
-        await testHelpers.expectThrow(
-            augmintToken.setName("Unauthorized Name", { from: accounts[1] })
-        );
+        await testHelpers.expectThrow(augmintToken.setName("Unauthorized Name", { from: accounts[1] }));
         assert.equal(await augmintToken.name(), oldName);
 
         const newName = "New Name for Old Token";
@@ -93,12 +91,10 @@ contract("AugmintToken tests", accounts => {
         assert.equal(await augmintToken.name(), oldName);
     });
 
-    it("should change token symbol if caller has permission", async function() {
+    it("should change token symbol if caller has permission", async function () {
         const oldSymbol = await augmintToken.symbol();
 
-        await testHelpers.expectThrow(
-            augmintToken.setSymbol("UNAUTHORIZED", { from: accounts[1] })
-        );
+        await testHelpers.expectThrow(augmintToken.setSymbol("UNAUTHORIZED", { from: accounts[1] }));
         assert.equal(await augmintToken.symbol(), oldSymbol);
 
         const newSymbol = "NEW";

--- a/test/tokenTransfer.js
+++ b/test/tokenTransfer.js
@@ -1,115 +1,123 @@
 const testHelpers = new require("./helpers/testHelpers.js");
 const tokenTestHelpers = new require("./helpers/tokenTestHelpers.js");
 
+const BN = web3.utils.BN;
+
 let augmintToken = null;
 let minFee, maxFee, feePt, minFeeAmount, maxFeeAmount;
 let snapshotId;
 
-contract("Transfer Augmint tokens tests", accounts => {
-    before(async function() {
+contract("Transfer Augmint tokens tests", (accounts) => {
+    before(async function () {
         augmintToken = tokenTestHelpers.augmintToken;
+
         await Promise.all([
             tokenTestHelpers.issueToken(accounts[0], accounts[0], 500000000),
-            tokenTestHelpers.issueToken(accounts[0], accounts[1], 500000000)
+            tokenTestHelpers.issueToken(accounts[0], accounts[1], 500000000),
         ]);
-        [feePt, minFee, maxFee] = await tokenTestHelpers.feeAccount.transferFee();
-        minFeeAmount = minFee.div(feePt).mul(1000000);
-        maxFeeAmount = maxFee.div(feePt).mul(1000000);
+
+        const feeParams = await tokenTestHelpers.feeAccount.transferFee();
+        feePt = feeParams.pt;
+        minFee = feeParams.min;
+        maxFee = feeParams.max;
+
+        minFeeAmount = minFee.mul(testHelpers.PPM_DIV).div(feePt);
+        maxFeeAmount = maxFee.mul(testHelpers.PPM_DIV).div(feePt);
     });
 
-    beforeEach(async function() {
+    beforeEach(async function () {
         snapshotId = await testHelpers.takeSnapshot();
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
         await testHelpers.revertSnapshot(snapshotId);
     });
 
-    it("Should be able to transfer tokens between accounts (without narrative, min fee)", async function() {
+    it("Should be able to transfer tokens between accounts (without narrative, min fee)", async function () {
         await tokenTestHelpers.transferTest(this, {
             from: accounts[1],
             to: accounts[2],
-            amount: minFeeAmount.sub(10),
-            narrative: ""
+            amount: minFeeAmount.sub(new BN(10)),
+            narrative: "",
         });
     });
 
-    it("Should be able to transfer tokens between accounts (with narrative, max fee)", async function() {
+    it("Should be able to transfer tokens between accounts (with narrative, max fee)", async function () {
         await tokenTestHelpers.transferTest(this, {
             from: accounts[1],
             to: accounts[2],
-            amount: maxFeeAmount.add(10),
-            narrative: "test narrative"
+            amount: maxFeeAmount.add(new BN(10)),
+            narrative: "test narrative",
         });
     });
 
-    it("transfer fee % should deducted when fee % is between min and max fee", async function() {
+    it("transfer fee % should deducted when fee % is between min and max fee", async function () {
         await tokenTestHelpers.transferTest(this, {
             from: accounts[1],
             to: accounts[2],
-            amount: maxFeeAmount.sub(10),
-            narrative: ""
+            amount: maxFeeAmount.sub(new BN(10)),
+            narrative: "",
         });
     });
 
-    it("Should be able to transfer 0 amount without narrative", async function() {
+    it("Should be able to transfer 0 amount without narrative", async function () {
         await tokenTestHelpers.transferTest(this, {
             from: accounts[1],
             to: accounts[2],
-            amount: 0,
-            narrative: ""
+            amount: new BN(0),
+            narrative: "",
         });
     });
 
-    it("Should be able to transfer 0 with narrative", async function() {
+    it("Should be able to transfer 0 with narrative", async function () {
         await tokenTestHelpers.transferTest(this, {
             from: accounts[1],
             to: accounts[2],
-            amount: 0,
-            narrative: "test narrative"
+            amount: new BN(0),
+            narrative: "test narrative",
         });
     });
 
-    it("Shouldn't be able to transfer tokens when token balance is insufficient", async function() {
+    it("Shouldn't be able to transfer tokens when token balance is insufficient", async function () {
         await testHelpers.expectThrow(
-            augmintToken.transfer(accounts[2], (await augmintToken.balanceOf(accounts[1])).plus(1), {
-                from: accounts[1]
+            augmintToken.transfer(accounts[2], (await augmintToken.balanceOf(accounts[1])).add(new BN(1)), {
+                from: accounts[1],
             })
         );
     });
 
-    it("Should be able to transfer tokens between the same accounts", async function() {
+    it("Should be able to transfer tokens between the same accounts", async function () {
         await tokenTestHelpers.transferTest(this, {
             from: accounts[1],
             to: accounts[1],
-            amount: 100
+            amount: new BN(100),
         });
     });
 
-    it("Shouldn't be able to transfer to 0x0", async function() {
+    it("Shouldn't be able to transfer to 0x0", async function () {
         await testHelpers.expectThrow(
-            augmintToken.transfer("0x0", 20000, {
-                from: accounts[1]
+            augmintToken.transfer("0x0000000000000000000000000000000000000000", 20000, {
+                from: accounts[1],
             })
         );
     });
 
-    it("should have zero fee if 'to' or 'from' is NoTransferFee", async function() {
-        await tokenTestHelpers.feeAccount.grantPermission(accounts[0], "NoTransferFee");
+    it("should have zero fee if 'to' or 'from' is NoTransferFee", async function () {
+        await tokenTestHelpers.feeAccount.grantPermission(accounts[0], web3.utils.asciiToHex("NoTransferFee"));
         await tokenTestHelpers.transferTest(this, {
             from: accounts[0],
             to: accounts[1],
-            amount: 10000,
+            amount: new BN(10000),
             narrative: "",
-            fee: 0
+            fee: new BN(0),
         });
 
         await tokenTestHelpers.transferTest(this, {
             from: accounts[1],
             to: accounts[0],
-            amount: 10000,
+            amount: new BN(10000),
             narrative: "transfer 0 test",
-            fee: 0
+            fee: new BN(0),
         });
     });
 });

--- a/test/tokenTransferFrom.js
+++ b/test/tokenTransferFrom.js
@@ -5,48 +5,52 @@ let augmintToken = null;
 let maxFee = null;
 let snapshotId;
 
-contract("TransferFrom AugmintToken tests", accounts => {
-    before(async function() {
+const BN = web3.utils.BN;
+
+contract("TransferFrom AugmintToken tests", (accounts) => {
+    before(async function () {
         augmintToken = tokenTestHelpers.augmintToken;
 
-        [[, , maxFee], ,] = await Promise.all([
+        const [feeParams, ,] = await Promise.all([
             tokenTestHelpers.feeAccount.transferFee(),
             tokenTestHelpers.issueToken(accounts[0], accounts[0], 500000000),
-            tokenTestHelpers.issueToken(accounts[0], accounts[1], 500000000)
+            tokenTestHelpers.issueToken(accounts[0], accounts[1], 500000000),
         ]);
+
+        maxFee = feeParams.max;
     });
 
-    beforeEach(async function() {
+    beforeEach(async function () {
         snapshotId = await testHelpers.takeSnapshot();
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
         await testHelpers.revertSnapshot(snapshotId);
     });
 
-    it("transferFrom", async function() {
+    it("transferFrom", async function () {
         const from = accounts[1];
         const to = accounts[2];
 
         const transfer1 = {
             from: from,
             to: to,
-            amount: 75000
+            amount: new BN(75000),
         };
         const fee1 = await tokenTestHelpers.getTransferFee(transfer1);
 
         const transfer2 = {
             from: from,
             to: to,
-            amount: 25000,
-            narrative: "Test with narrative"
+            amount: new BN(25000),
+            narrative: "Test with narrative",
         };
         const fee2 = await tokenTestHelpers.getTransferFee(transfer2);
 
         const expApprove = {
             owner: from,
             spender: to,
-            value: transfer1.amount + fee1 + transfer2.amount + fee2
+            value: transfer1.amount + fee1 + transfer2.amount + fee2,
         };
 
         await tokenTestHelpers.approveTest(this, expApprove);
@@ -54,11 +58,11 @@ contract("TransferFrom AugmintToken tests", accounts => {
         await tokenTestHelpers.transferFromTest(this, transfer2);
     });
 
-    it("transferFrom spender to send to different to than itself", async function() {
+    it("transferFrom spender to send to different to than itself", async function () {
         const expApprove = {
             owner: accounts[1],
             spender: accounts[2],
-            value: 200000
+            value: 200000,
         };
 
         await tokenTestHelpers.approveTest(this, expApprove);
@@ -67,115 +71,115 @@ contract("TransferFrom AugmintToken tests", accounts => {
             from: expApprove.owner,
             spender: expApprove.spender,
             to: accounts[2],
-            amount: Math.round(expApprove.value / 2),
-            narrative: "Test with narrative"
+            amount: new BN(Math.round(expApprove.value / 2)),
+            narrative: "Test with narrative",
         });
     });
 
-    it("Shouldn't approve 0x0 spender", async function() {
+    it("Shouldn't approve 0x0 spender", async function () {
         await testHelpers.expectThrow(
-            augmintToken.approve("0x0", 100, {
-                from: accounts[2]
+            augmintToken.approve("0x0000000000000000000000000000000000000000", 100, {
+                from: accounts[2],
             })
         );
     });
 
-    it("transferFrom only if approved", async function() {
+    it("transferFrom only if approved", async function () {
         await testHelpers.expectThrow(
             augmintToken.transferFrom(accounts[0], accounts[2], 100, {
-                from: accounts[2]
+                from: accounts[2],
             })
         );
     });
 
-    it("should transferFrom 0 amount when some approved", async function() {
+    it("should transferFrom 0 amount when some approved", async function () {
         const expApprove = {
             owner: accounts[1],
             spender: accounts[2],
-            value: 100000
+            value: 100000,
         };
 
         await tokenTestHelpers.approveTest(this, expApprove);
         await tokenTestHelpers.transferFromTest(this, {
             from: expApprove.owner,
             spender: expApprove.spender,
-            amount: 0,
-            narrative: "Test with narrative"
+            amount: new BN(0),
+            narrative: "Test with narrative",
         });
     });
 
-    it("shouldn't transferFrom even 0 amount when not approved", async function() {
+    it("shouldn't transferFrom even 0 amount when not approved", async function () {
         const expApprove = {
             owner: accounts[1],
             spender: accounts[2],
-            value: 0
+            value: 0,
         };
 
         await tokenTestHelpers.approveTest(this, expApprove);
         await testHelpers.expectThrow(
             augmintToken.transferFrom(expApprove.owner, expApprove.spender, 0, {
-                from: expApprove.spender
+                from: expApprove.spender,
             })
         );
     });
 
-    it("shouldn't transferFrom to 0x0", async function() {
+    it("shouldn't transferFrom to 0x0", async function () {
         const expApprove = {
             owner: accounts[1],
             spender: accounts[2],
-            value: 10000
+            value: 10000,
         };
 
         await tokenTestHelpers.approveTest(this, expApprove);
         await testHelpers.expectThrow(
-            augmintToken.transferFrom(expApprove.owner, "0x0", 0, {
-                from: expApprove.spender
+            augmintToken.transferFrom(expApprove.owner, "0x0000000000000000000000000000000000000000", 0, {
+                from: expApprove.spender,
             })
         );
     });
 
-    it("transferFrom only if approved is greater than amount", async function() {
+    it("transferFrom only if approved is greater than amount", async function () {
         const expApprove = {
             owner: accounts[1],
             spender: accounts[2],
-            value: 200000
+            value: 200000,
         };
 
         await tokenTestHelpers.approveTest(this, expApprove);
         await testHelpers.expectThrow(
             augmintToken.transferFrom(expApprove.owner, expApprove.spender, expApprove.value + 1, {
-                from: expApprove.spender
+                from: expApprove.spender,
             })
         );
     });
 
-    it("transferFrom only if balance is enough", async function() {
+    it("transferFrom only if balance is enough", async function () {
         await augmintToken.transfer(accounts[1], maxFee, { from: accounts[0] }); // to cover the transfer fee
         const amount = await augmintToken.balanceOf(accounts[0]);
         const expApprove = {
             owner: accounts[1],
             spender: accounts[2],
-            value: amount
+            value: amount,
         };
         await tokenTestHelpers.approveTest(this, expApprove);
 
         await testHelpers.expectThrow(
             augmintToken.transferFrom(expApprove.owner, expApprove.spender, expApprove.value + 1, {
-                from: expApprove.spender
+                from: expApprove.spender,
             })
         );
     });
 
-    it("should have zero fee for transferFrom if 'to' is NoTransferFee", async function() {});
+    it("should have zero fee for transferFrom if 'to' is NoTransferFee", async function () {});
 
-    it("should have zero fee for transferFrom if 'from' or 'to' is NoTransferFee ", async function() {
-        await tokenTestHelpers.feeAccount.grantPermission(accounts[0], "NoTransferFee");
+    it("should have zero fee for transferFrom if 'from' or 'to' is NoTransferFee ", async function () {
+        await tokenTestHelpers.feeAccount.grantPermission(accounts[0], web3.utils.asciiToHex("NoTransferFee"));
 
         const expApprove1 = {
             owner: accounts[0],
             spender: accounts[1],
             to: accounts[2],
-            value: 100000
+            value: 100000,
         };
         await tokenTestHelpers.approveTest(this, expApprove1);
 
@@ -183,15 +187,15 @@ contract("TransferFrom AugmintToken tests", accounts => {
             from: expApprove1.owner,
             spender: expApprove1.spender,
             to: expApprove1.to,
-            amount: expApprove1.value,
-            fee: 0
+            amount: new BN(expApprove1.value),
+            fee: new BN(0),
         });
 
         const expApprove2 = {
             owner: accounts[1],
             spender: accounts[0],
             to: accounts[0],
-            value: 100000
+            value: 100000,
         };
         await tokenTestHelpers.approveTest(this, expApprove2);
 
@@ -199,21 +203,21 @@ contract("TransferFrom AugmintToken tests", accounts => {
             from: expApprove2.owner,
             spender: expApprove2.spender,
             to: expApprove2.to,
-            amount: expApprove2.value,
-            fee: 0
+            amount: new BN(expApprove2.value),
+            fee: new BN(0),
         });
     });
 
-    it("increaseApproval", async function() {
+    it("increaseApproval", async function () {
         const expApprove = {
             owner: accounts[0],
             spender: accounts[1],
-            value: 100000
+            value: new BN(100000),
         };
         const startingAllowance = await augmintToken.allowance(expApprove.owner, expApprove.spender);
 
         const tx = await augmintToken.increaseApproval(expApprove.spender, expApprove.value, {
-            from: expApprove.owner
+            from: expApprove.owner,
         });
         testHelpers.logGasUse(this, tx, "increaseApproval");
 
@@ -228,19 +232,19 @@ contract("TransferFrom AugmintToken tests", accounts => {
         );
     });
 
-    it("decreaseApproval", async function() {
+    it("decreaseApproval", async function () {
         const startingAllowance = 300000;
         const decreaseValue = 50000;
         const expApprove = {
             owner: accounts[0],
             spender: accounts[1],
-            value: startingAllowance - decreaseValue
+            value: startingAllowance - decreaseValue,
         };
 
         await augmintToken.approve(expApprove.spender, startingAllowance, { from: expApprove.owner });
 
         const tx = await augmintToken.decreaseApproval(expApprove.spender, decreaseValue, {
-            from: expApprove.owner
+            from: expApprove.owner,
         });
         testHelpers.logGasUse(this, tx, "decreaseApproval");
 
@@ -255,19 +259,19 @@ contract("TransferFrom AugmintToken tests", accounts => {
         );
     });
 
-    it("decreaseApproval to 0", async function() {
+    it("decreaseApproval to 0", async function () {
         const startingAllowance = 2000;
         const decreaseValue = 3000;
         const expApprove = {
             owner: accounts[0],
             spender: accounts[1],
-            value: 0
+            value: 0,
         };
 
         await augmintToken.approve(expApprove.spender, startingAllowance, { from: expApprove.owner });
 
         const tx = await augmintToken.decreaseApproval(expApprove.spender, decreaseValue, {
-            from: expApprove.owner
+            from: expApprove.owner,
         });
         testHelpers.logGasUse(this, tx, "decreaseApproval");
 

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -8,37 +8,47 @@ const MNEMONIC = process.env.DEPLOYER_MNEMONIC;
 const INFURA_API_KEY = process.env.INFURA_API_KEY;
 
 module.exports = {
-    /* TODO: tempfix because of issue: https://github.com/trufflesuite/truffle-migrate/issues/10
-          for now ./build/contracts need to be copied manually to src/contractsBuild folder after every truffle migrate
-    */
-    //contracts_build_directory: './src/contractsBuild',
-    //working_directory: './contracts',
-    //migrations_directory: './migrations',
+    // Workaround of --migrations_directory flag removed truffle test.
+    // We will pass --migrations_directory to truffle migrate instead (./migrations)
+    migrations_directory: "./migrations_null",
+    compilers: {
+        solc: {
+            version: "0.4.24",
+            docker: false, // TODO: check if we could use this for better docker integration
+            parser: "solcjs", // Leverages solc-js purely for speedy parsing
+            settings: {
+                optimizer: {
+                    enabled: false,
+                },
+                // evmVersion: <string> // Default: "petersburg"
+            },
+        },
+    },
     networks: {
         development: {
             host: "localhost",
             port: 8545,
             network_id: "999",
-            gasPrice: 1000000000 // 1 GWEI
+            gasPrice: 1000000000, // 1 GWEI
         },
         coverage: {
             host: "localhost",
             network_id: "*",
             port: 8555, // <-- If you change this, also set the port option in .solcover.js.
             gas: 0xfffffffffff, // <-- Use this high gas value
-            gasPrice: 0x01 // <-- Use this low gas price
+            gasPrice: 0x01, // <-- Use this low gas price
         },
         truffleLocal: {
             host: "localhost",
             port: 9545,
             network_id: "4447",
-            gas: 4707806
+            gas: 4707806,
         },
         privatechain: {
             host: "localhost",
             port: 8565,
             network_id: "1976",
-            gas: 4707806
+            gas: 4707806,
         },
         rinkeby: {
             host: "localhost", // Connect to geth on the specified
@@ -46,7 +56,7 @@ module.exports = {
             from: "0xae653250B4220835050B75D3bC91433246903A95", // default address to use for any transaction Truffle makes during migrations
             network_id: 4,
             gas: 4700000, // Gas limit used for deploys
-            gasPrice: 1000000000 // 1 Gwei
+            gasPrice: 1000000000, // 1 Gwei
         },
         rinkebyFork: {
             // Rinkeby deploy Forks for dry runs.
@@ -57,23 +67,19 @@ module.exports = {
             from: "0xae653250B4220835050B75D3bC91433246903A95", // default address to use for any transaction Truffle makes during migrations
             network_id: 4,
             gas: 4700000, // Gas limit used for deploys
-            gasPrice: 1000000000 // 1 Gwei
+            gasPrice: 1000000000, // 1 Gwei
         },
         ropsten: {
             host: "localhost", // Connect to geth on the specified
             port: 8545,
             network_id: 3,
             gas: 4700000, // Gas limit used for deploys
-            gasPrice: 140000000000 // 140 Gwei
+            gasPrice: 140000000000, // 140 Gwei
         },
         mainnet: {
-            provider: () =>
-                new HDWalletProvider(
-                    MNEMONIC,
-                    "https://mainnet.infura.io/" + INFURA_API_KEY
-                ),
+            provider: () => new HDWalletProvider(MNEMONIC, "https://mainnet.infura.io/" + INFURA_API_KEY),
             network_id: 1,
-            gasPrice: 6000000000 // 6 Gwei
-        }
-    }
+            gasPrice: 6000000000, // 6 Gwei
+        },
+    },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
 "@types/node@^10.3.2":
-  version "10.17.30"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.30.tgz#20556a0d7f62b83e163973a6cd640af636d3dd3b"
-  integrity sha512-euU8QLX0ipj+5mOYa4ZqZoTv+53BY7yTg9I2ZIhDXgiI3M+0n4mdAt9TQCuvxVAgU179g8OsRLaBt0qEi0T6xA==
+  version "10.17.32"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.32.tgz#4ef6ff8b842ea0eb3fcbc4331489f4ae64036fa8"
+  integrity sha512-EUq+cjH/3KCzQHikGnNbWAGe548IFLSm93Vl8xA7EuYEEATiyOVDyEVuGkowL7c9V69FF/RiZSAOCFPApMs/ig==
 
 abbrev@1:
   version "1.1.1"
@@ -85,6 +90,11 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
+ansi-colors@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+
 ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -117,10 +127,31 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
+
 any-promise@1.3.0, any-promise@^1.0.0, any-promise@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
   integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
+
+anymatch@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
+  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
+app-module-path@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/app-module-path/-/app-module-path-2.2.0.tgz#641aa55dfb7d6a6f0a8141c4b9c0aa50b6c24dd5"
+  integrity sha1-ZBqlXft9am8KgUHEucCqULbCTdU=
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -133,6 +164,16 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+
+array.prototype.map@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array.prototype.map/-/array.prototype.map-1.0.2.tgz#9a4159f416458a23e9483078de1106b2ef68f8ec"
+  integrity sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    es-array-method-boxes-properly "^1.0.0"
+    is-string "^1.0.4"
 
 asn1.js@^5.2.0:
   version "5.4.1"
@@ -328,14 +369,14 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bignumber.js@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-5.0.0.tgz#fbce63f09776b3000a83185badcde525daf34833"
-  integrity sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg==
-
 "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2":
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+
+binary-extensions@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
+  integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
 
 bindings@^1.2.1, bindings@^1.3.1, bindings@^1.5.0:
   version "1.5.0"
@@ -415,6 +456,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+braces@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
+
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
@@ -424,6 +472,11 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
   integrity sha1-81HTKWnTL6XXpVZxVCY9korjvR8=
+
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+  integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4, browserify-aes@^1.0.6:
   version "1.2.0"
@@ -555,7 +608,7 @@ camelcase@^3.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
   integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
 
-camelcase@^5.0.0:
+camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -585,6 +638,14 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -594,6 +655,21 @@ charenc@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
+chokidar@3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
+  integrity sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.4.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -645,10 +721,22 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -844,7 +932,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1:
+debug@4.1.1, debug@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -926,6 +1014,13 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+define-properties@^1.1.2, define-properties@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -960,6 +1055,11 @@ diff@3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
   integrity sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==
+
+diff@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -1061,6 +1161,68 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.17.0-next.1, es-abstract@^1.17.4, es-abstract@^1.17.5:
+  version "1.17.6"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
+  integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.0"
+    is-regex "^1.1.0"
+    object-inspect "^1.7.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.0"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
+es-abstract@^1.18.0-next.0:
+  version "1.18.0-next.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.0.tgz#b302834927e624d8e5837ed48224291f2c66e6fc"
+  integrity sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.0"
+    is-negative-zero "^2.0.0"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.0"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
+es-array-method-boxes-properly@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
+  integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
+
+es-get-iterator@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.0.tgz#bb98ad9d6d63b31aacdc8f89d5d0ee57bcb5b4c8"
+  integrity sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==
+  dependencies:
+    es-abstract "^1.17.4"
+    has-symbols "^1.0.1"
+    is-arguments "^1.0.4"
+    is-map "^2.0.1"
+    is-set "^2.0.1"
+    is-string "^1.0.5"
+    isarray "^2.0.5"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
+
 es5-ext@^0.10.35, es5-ext@^0.10.50:
   version "0.10.53"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
@@ -1096,6 +1258,11 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escape-string-regexp@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escodegen@1.8.x:
   version "1.8.1"
@@ -1472,6 +1639,13 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -1484,6 +1658,14 @@ finalhandler@~1.1.2:
     parseurl "~1.3.3"
     statuses "~1.5.0"
     unpipe "~1.0.0"
+
+find-up@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -1508,6 +1690,13 @@ flat-cache@^2.0.1:
     flatted "^2.0.0"
     rimraf "2.6.3"
     write "1.0.3"
+
+flat@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.0.tgz#090bec8b05e39cba309747f1d588f04dbaf98db2"
+  integrity sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==
+  dependencies:
+    is-buffer "~2.0.3"
 
 flatted@^2.0.0:
   version "2.0.2"
@@ -1543,17 +1732,6 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@^0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
-  integrity sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
-    klaw "^1.0.0"
-    path-is-absolute "^1.0.0"
-    rimraf "^2.2.8"
-
 fs-extra@^2.0.0, fs-extra@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
@@ -1577,6 +1755,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fsevents@~2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
+  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
 fstream@^1.0.12, fstream@^1.0.8:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
@@ -1586,6 +1769,11 @@ fstream@^1.0.12, fstream@^1.0.8:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
+
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
@@ -1648,10 +1836,29 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
+glob-parent@~5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
+  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob@7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   integrity sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@7.1.6, glob@^7.0.0, glob@^7.1.3:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1668,18 +1875,6 @@ glob@^5.0.15:
     inflight "^1.0.4"
     inherits "2"
     minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.0, glob@^7.1.3:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -1721,7 +1916,7 @@ got@7.1.0, got@^7.1.0:
     url-parse-lax "^1.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.10, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.10, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -1731,7 +1926,7 @@ growl@1.10.3:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
   integrity sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==
 
-"growl@~> 1.10.0":
+growl@1.10.5, "growl@~> 1.10.0":
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
@@ -1783,10 +1978,20 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
 has-symbol-support-x@^1.4.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
   integrity sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==
+
+has-symbols@^1.0.0, has-symbols@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
+  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
 has-to-string-tag-x@^1.2.0:
   version "1.4.1"
@@ -1794,6 +1999,13 @@ has-to-string-tag-x@^1.2.0:
   integrity sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==
   dependencies:
     has-symbol-support-x "^1.4.1"
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 hash-base@^3.0.0:
   version "3.1.0"
@@ -1824,6 +2036,11 @@ he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
   integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
+
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -1994,15 +2211,42 @@ ipaddr.js@1.9.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
+is-arguments@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
+  integrity sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@~2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
+
+is-callable@^1.1.4, is-callable@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.1.tgz#4d1e21a4f437509d25ce55f8184350771421c96d"
+  integrity sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg==
+
+is-date-object@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
+  integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
 
 is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
@@ -2038,7 +2282,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -2050,10 +2294,25 @@ is-hex-prefixed@1.0.0:
   resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
   integrity sha1-fY035q135dEnFIkTxXPggtd39VQ=
 
+is-map@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.1.tgz#520dafc4307bb8ebc33b813de5ce7c9400d644a1"
+  integrity sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==
+
 is-natural-number@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
   integrity sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=
+
+is-negative-zero@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz#9553b121b0fac28869da9ed459e20c7543788461"
+  integrity sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-object@^1.0.1:
   version "1.0.1"
@@ -2065,15 +2324,39 @@ is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
+is-regex@^1.1.0, is-regex@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
+  integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
+  dependencies:
+    has-symbols "^1.0.1"
+
 is-retry-allowed@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
   integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
 
+is-set@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.1.tgz#d1604afdab1724986d30091575f54945da7e5f43"
+  integrity sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==
+
 is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
+is-string@^1.0.4, is-string@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
+  integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
+
+is-symbol@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
+  integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
+  dependencies:
+    has-symbols "^1.0.1"
 
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
@@ -2084,6 +2367,11 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
+
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -2135,6 +2423,19 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
+iterate-iterator@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/iterate-iterator/-/iterate-iterator-1.0.1.tgz#1693a768c1ddd79c969051459453f082fe82e9f6"
+  integrity sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==
+
+iterate-value@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/iterate-value/-/iterate-value-1.0.2.tgz#935115bd37d006a52046535ebc8d07e9c9337f57"
+  integrity sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==
+  dependencies:
+    es-get-iterator "^1.0.2"
+    iterate-iterator "^1.0.1"
+
 joi@^13.0.0:
   version "13.7.0"
   resolved "https://registry.yarnpkg.com/joi/-/joi-13.7.0.tgz#cfd85ebfe67e8a1900432400b4d03bbd93fb879f"
@@ -2164,7 +2465,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.x, js-yaml@^3.11.0, js-yaml@^3.13.1:
+js-yaml@3.14.0, js-yaml@3.x, js-yaml@^3.11.0, js-yaml@^3.13.1:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
@@ -2254,13 +2555,6 @@ keccakjs@^0.2.1:
     browserify-sha3 "^0.0.4"
     sha3 "^1.2.2"
 
-klaw@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
-  integrity sha1-QIhDO0azsbolnXh4XY6W9zugJDk=
-  optionalDependencies:
-    graceful-fs "^4.1.9"
-
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
@@ -2307,6 +2601,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash.assign@^4.0.3, lodash.assign@^4.0.6:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
@@ -2321,6 +2622,13 @@ log-driver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
   integrity sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
+
+log-symbols@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
+  integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
+  dependencies:
+    chalk "^4.0.0"
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -2379,11 +2687,6 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
-
-memorystream@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
-  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -2452,7 +2755,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-"minimatch@2 || 3", minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -2495,6 +2798,37 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mocha@8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.1.2.tgz#d67fad13300e4f5cd48135a935ea566f96caf827"
+  integrity sha512-I8FRAcuACNMLQn3lS4qeWLxXqLvGf6r2CaLstDpZmMUUSmvW6Cnm1AuHxgbc7ctZVRcfwspCRbDHymPsi3dkJw==
+  dependencies:
+    ansi-colors "4.1.1"
+    browser-stdout "1.3.1"
+    chokidar "3.4.2"
+    debug "4.1.1"
+    diff "4.0.2"
+    escape-string-regexp "4.0.0"
+    find-up "5.0.0"
+    glob "7.1.6"
+    growl "1.10.5"
+    he "1.2.0"
+    js-yaml "3.14.0"
+    log-symbols "4.0.0"
+    minimatch "3.0.4"
+    ms "2.1.2"
+    object.assign "4.1.0"
+    promise.allsettled "1.0.2"
+    serialize-javascript "4.0.0"
+    strip-json-comments "3.0.1"
+    supports-color "7.1.0"
+    which "2.0.2"
+    wide-align "1.1.3"
+    workerpool "6.0.0"
+    yargs "13.3.2"
+    yargs-parser "13.1.2"
+    yargs-unparser "1.6.1"
+
 mocha@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-4.1.0.tgz#7d86cfbcf35cb829e2754c32e17355ec05338794"
@@ -2536,7 +2870,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@^2.1.1:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -2617,6 +2951,11 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@^3.0.0, normalize-path@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -2646,6 +2985,36 @@ object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+object-inspect@^1.7.0, object-inspect@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
+  integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
+
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object.assign@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
+
+object.assign@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.1.tgz#303867a666cdd41936ecdedfb1f8f3e32a478cdd"
+  integrity sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.0"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
 
 oboe@2.1.3:
   version "2.1.3"
@@ -2745,12 +3114,26 @@ p-limit@^2.0.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz#1664e010af3cadc681baafd3e2a437be7b0fb5fe"
+  integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
   integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
   dependencies:
     p-limit "^2.0.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-timeout@^1.1.1:
   version "1.2.1"
@@ -2816,6 +3199,11 @@ path-exists@^3.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
 path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -2871,6 +3259,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+picomatch@^2.0.4, picomatch@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -2922,6 +3315,17 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+promise.allsettled@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/promise.allsettled/-/promise.allsettled-1.0.2.tgz#d66f78fbb600e83e863d893e98b3d4376a9c47c9"
+  integrity sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==
+  dependencies:
+    array.prototype.map "^1.0.1"
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    function-bind "^1.1.1"
+    iterate-value "^1.0.0"
 
 proxy-addr@~2.0.5:
   version "2.0.6"
@@ -2992,7 +3396,7 @@ random-seed@0.3.0:
   dependencies:
     json-stringify-safe "^5.0.1"
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -3066,6 +3470,13 @@ readable-stream@^3.6.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readdirp@~3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
+  integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
+  dependencies:
+    picomatch "^2.2.1"
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
@@ -3135,11 +3546,6 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
-require-from-string@^1.1.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
-  integrity sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=
-
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -3180,7 +3586,7 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
-rimraf@2, rimraf@^2.2.8:
+rimraf@2:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -3289,7 +3695,7 @@ seek-bzip@^1.0.5:
   dependencies:
     commander "^2.8.1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.5.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -3312,6 +3718,13 @@ send@0.17.1:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
+
+serialize-javascript@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
+  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
 
 serve-static@1.14.1:
   version "1.14.1"
@@ -3427,17 +3840,6 @@ sol-explore@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/sol-explore/-/sol-explore-1.6.2.tgz#43ae8c419fd3ac056a05f8a9d1fb1022cd41ecc2"
   integrity sha1-Q66MQZ/TrAVqBfip0fsQIs1B7MI=
-
-solc@0.4.24:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.24.tgz#354f14b269b38cbaa82a47d1ff151723502b954e"
-  integrity sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==
-  dependencies:
-    fs-extra "^0.30.0"
-    memorystream "^0.3.1"
-    require-from-string "^1.1.0"
-    semver "^5.3.0"
-    yargs "^4.7.1"
 
 solidity-coverage@0.5.11:
   version "0.5.11"
@@ -3569,7 +3971,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.1.0:
+"string-width@^1.0.2 || 2", string-width@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -3585,6 +3987,22 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string.prototype.trimend@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
+  integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+
+string.prototype.trimstart@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
+  integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -3655,6 +4073,11 @@ strip-hex-prefix@1.0.0:
   dependencies:
     is-hex-prefixed "1.0.0"
 
+strip-json-comments@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
+  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
+
 strip-json-comments@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -3666,6 +4089,13 @@ supports-color@4.4.0:
   integrity sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==
   dependencies:
     has-flag "^2.0.0"
+
+supports-color@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -3685,6 +4115,13 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
 
 swarm-js@0.1.37:
   version "0.1.37"
@@ -3794,6 +4231,13 @@ to-fast-properties@^1.0.3:
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
   integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
 
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
@@ -3839,14 +4283,14 @@ truffle-hdwallet-provider@1.0.13:
     web3 "1.0.0-beta.37"
     websocket "^1.0.28"
 
-truffle@4.1.14:
-  version "4.1.14"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-4.1.14.tgz#8d2c298e29abf9b1e486e44ff9faca6d34bb9030"
-  integrity sha512-e7tTLvKP3bN9dE7MagfWyFjy4ZgoEGbeujECy1me1ENBzbj/aO/+45gs72qsL3+3IkCNNcWNOJjjrm8BYZZNNg==
+truffle@5.1.43:
+  version "5.1.43"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.1.43.tgz#544e7b0955b6728a00761a86555c1eb259313266"
+  integrity sha512-KXda/70RAG9TBdQta8JEwVQmL9r/AZzU++5aZkrF4/nDosund8SV1yM9CcDTib4xLWuMaB15YyOC5r163QdLAw==
   dependencies:
-    mocha "^4.1.0"
+    app-module-path "^2.2.0"
+    mocha "8.1.2"
     original-require "1.0.1"
-    solc "0.4.24"
 
 tslib@^1.9.0:
   version "1.13.0"
@@ -4024,15 +4468,6 @@ wait-on@3.2.0:
     request "^2.88.0"
     rx "^4.1.0"
 
-web3-bzz@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.0.0-beta.34.tgz#068d37777ab65e5c60f8ec8b9a50cfe45277929c"
-  integrity sha1-Bo03d3q2Xlxg+OyLmlDP5FJ3kpw=
-  dependencies:
-    got "7.1.0"
-    swarm-js "0.1.37"
-    underscore "1.8.3"
-
 web3-bzz@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.0.0-beta.37.tgz#59e3e4f5a9d732731008fe9165c3ec8bf85d502f"
@@ -4042,15 +4477,6 @@ web3-bzz@1.0.0-beta.37:
     swarm-js "0.1.37"
     underscore "1.8.3"
 
-web3-core-helpers@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz#b168da00d3e19e156bc15ae203203dd4dfee2d03"
-  integrity sha1-sWjaANPhnhVrwVriAyA91N/uLQM=
-  dependencies:
-    underscore "1.8.3"
-    web3-eth-iban "1.0.0-beta.34"
-    web3-utils "1.0.0-beta.34"
-
 web3-core-helpers@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.37.tgz#04ec354b7f5c57234c309eea2bda9bf1f2fe68ba"
@@ -4059,17 +4485,6 @@ web3-core-helpers@1.0.0-beta.37:
     underscore "1.8.3"
     web3-eth-iban "1.0.0-beta.37"
     web3-utils "1.0.0-beta.37"
-
-web3-core-method@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.0.0-beta.34.tgz#ec163c8a2c490fa02a7ec15559fa7307fc7cc6dd"
-  integrity sha1-7BY8iixJD6AqfsFVWfpzB/x8xt0=
-  dependencies:
-    underscore "1.8.3"
-    web3-core-helpers "1.0.0-beta.34"
-    web3-core-promievent "1.0.0-beta.34"
-    web3-core-subscriptions "1.0.0-beta.34"
-    web3-utils "1.0.0-beta.34"
 
 web3-core-method@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -4082,14 +4497,6 @@ web3-core-method@1.0.0-beta.37:
     web3-core-subscriptions "1.0.0-beta.37"
     web3-utils "1.0.0-beta.37"
 
-web3-core-promievent@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.34.tgz#a4f4fa6784bb293e82c60960ae5b56a94cd03edc"
-  integrity sha1-pPT6Z4S7KT6CxglgrltWqUzQPtw=
-  dependencies:
-    any-promise "1.3.0"
-    eventemitter3 "1.1.1"
-
 web3-core-promievent@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.37.tgz#4e51c469d0a7ac0a969885a4dbcde8504abe5b02"
@@ -4097,17 +4504,6 @@ web3-core-promievent@1.0.0-beta.37:
   dependencies:
     any-promise "1.3.0"
     eventemitter3 "1.1.1"
-
-web3-core-requestmanager@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.34.tgz#01f8f6cf2ae6b6f0b70c38bae1ef741b5bab215c"
-  integrity sha1-Afj2zyrmtvC3DDi64e90G1urIVw=
-  dependencies:
-    underscore "1.8.3"
-    web3-core-helpers "1.0.0-beta.34"
-    web3-providers-http "1.0.0-beta.34"
-    web3-providers-ipc "1.0.0-beta.34"
-    web3-providers-ws "1.0.0-beta.34"
 
 web3-core-requestmanager@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -4120,15 +4516,6 @@ web3-core-requestmanager@1.0.0-beta.37:
     web3-providers-ipc "1.0.0-beta.37"
     web3-providers-ws "1.0.0-beta.37"
 
-web3-core-subscriptions@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.34.tgz#9fed144033f221c3cf21060302ffdaf5ef2de2de"
-  integrity sha1-n+0UQDPyIcPPIQYDAv/a9e8t4t4=
-  dependencies:
-    eventemitter3 "1.1.1"
-    underscore "1.8.3"
-    web3-core-helpers "1.0.0-beta.34"
-
 web3-core-subscriptions@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.37.tgz#40de5e2490cc05b15faa8f935c97fd48d670cd9a"
@@ -4137,16 +4524,6 @@ web3-core-subscriptions@1.0.0-beta.37:
     eventemitter3 "1.1.1"
     underscore "1.8.3"
     web3-core-helpers "1.0.0-beta.37"
-
-web3-core@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.0.0-beta.34.tgz#121be8555e9fb00d2c5d05ddd3381d0c9e46987e"
-  integrity sha1-EhvoVV6fsA0sXQXd0zgdDJ5GmH4=
-  dependencies:
-    web3-core-helpers "1.0.0-beta.34"
-    web3-core-method "1.0.0-beta.34"
-    web3-core-requestmanager "1.0.0-beta.34"
-    web3-utils "1.0.0-beta.34"
 
 web3-core@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -4158,16 +4535,6 @@ web3-core@1.0.0-beta.37:
     web3-core-requestmanager "1.0.0-beta.37"
     web3-utils "1.0.0-beta.37"
 
-web3-eth-abi@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz#034533e3aa2f7e59ff31793eaea685c0ed5af67a"
-  integrity sha1-A0Uz46ovfln/MXk+rqaFwO1a9no=
-  dependencies:
-    bn.js "4.11.6"
-    underscore "1.8.3"
-    web3-core-helpers "1.0.0-beta.34"
-    web3-utils "1.0.0-beta.34"
-
 web3-eth-abi@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.37.tgz#55592fa9cd2427d9f0441d78f3b8d0c1359a2a24"
@@ -4176,22 +4543,6 @@ web3-eth-abi@1.0.0-beta.37:
     ethers "4.0.0-beta.1"
     underscore "1.8.3"
     web3-utils "1.0.0-beta.37"
-
-web3-eth-accounts@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.34.tgz#e09142eeecc797ac3459b75e9b23946d3695f333"
-  integrity sha1-4JFC7uzHl6w0WbdemyOUbTaV8zM=
-  dependencies:
-    any-promise "1.3.0"
-    crypto-browserify "3.12.0"
-    eth-lib "0.2.7"
-    scrypt.js "0.2.0"
-    underscore "1.8.3"
-    uuid "2.0.1"
-    web3-core "1.0.0-beta.34"
-    web3-core-helpers "1.0.0-beta.34"
-    web3-core-method "1.0.0-beta.34"
-    web3-utils "1.0.0-beta.34"
 
 web3-eth-accounts@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -4208,20 +4559,6 @@ web3-eth-accounts@1.0.0-beta.37:
     web3-core-helpers "1.0.0-beta.37"
     web3-core-method "1.0.0-beta.37"
     web3-utils "1.0.0-beta.37"
-
-web3-eth-contract@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.34.tgz#9dbb38fae7643a808427a20180470ec7415c91e6"
-  integrity sha1-nbs4+udkOoCEJ6IBgEcOx0FckeY=
-  dependencies:
-    underscore "1.8.3"
-    web3-core "1.0.0-beta.34"
-    web3-core-helpers "1.0.0-beta.34"
-    web3-core-method "1.0.0-beta.34"
-    web3-core-promievent "1.0.0-beta.34"
-    web3-core-subscriptions "1.0.0-beta.34"
-    web3-eth-abi "1.0.0-beta.34"
-    web3-utils "1.0.0-beta.34"
 
 web3-eth-contract@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -4251,14 +4588,6 @@ web3-eth-ens@1.0.0-beta.37:
     web3-eth-contract "1.0.0-beta.37"
     web3-utils "1.0.0-beta.37"
 
-web3-eth-iban@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz#9af458605867ccf74ea979aaf326b38ba6a5ba0c"
-  integrity sha1-mvRYYFhnzPdOqXmq8yazi6alugw=
-  dependencies:
-    bn.js "4.11.6"
-    web3-utils "1.0.0-beta.34"
-
 web3-eth-iban@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.37.tgz#313a3f18ae2ab00ba98678ea1156b09ef32a3655"
@@ -4266,17 +4595,6 @@ web3-eth-iban@1.0.0-beta.37:
   dependencies:
     bn.js "4.11.6"
     web3-utils "1.0.0-beta.37"
-
-web3-eth-personal@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.34.tgz#9afba167342ebde5420bcd5895c3f6c34388f205"
-  integrity sha1-mvuhZzQuveVCC81YlcP2w0OI8gU=
-  dependencies:
-    web3-core "1.0.0-beta.34"
-    web3-core-helpers "1.0.0-beta.34"
-    web3-core-method "1.0.0-beta.34"
-    web3-net "1.0.0-beta.34"
-    web3-utils "1.0.0-beta.34"
 
 web3-eth-personal@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -4288,24 +4606,6 @@ web3-eth-personal@1.0.0-beta.37:
     web3-core-method "1.0.0-beta.37"
     web3-net "1.0.0-beta.37"
     web3-utils "1.0.0-beta.37"
-
-web3-eth@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.0.0-beta.34.tgz#74086000850c6fe6f535ef49837d6d4bb6113268"
-  integrity sha1-dAhgAIUMb+b1Ne9Jg31tS7YRMmg=
-  dependencies:
-    underscore "1.8.3"
-    web3-core "1.0.0-beta.34"
-    web3-core-helpers "1.0.0-beta.34"
-    web3-core-method "1.0.0-beta.34"
-    web3-core-subscriptions "1.0.0-beta.34"
-    web3-eth-abi "1.0.0-beta.34"
-    web3-eth-accounts "1.0.0-beta.34"
-    web3-eth-contract "1.0.0-beta.34"
-    web3-eth-iban "1.0.0-beta.34"
-    web3-eth-personal "1.0.0-beta.34"
-    web3-net "1.0.0-beta.34"
-    web3-utils "1.0.0-beta.34"
 
 web3-eth@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -4326,15 +4626,6 @@ web3-eth@1.0.0-beta.37:
     web3-net "1.0.0-beta.37"
     web3-utils "1.0.0-beta.37"
 
-web3-net@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.0.0-beta.34.tgz#427cea2f431881449c8e38d523290f173f9ff63d"
-  integrity sha1-QnzqL0MYgUScjjjVIykPFz+f9j0=
-  dependencies:
-    web3-core "1.0.0-beta.34"
-    web3-core-method "1.0.0-beta.34"
-    web3-utils "1.0.0-beta.34"
-
 web3-net@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.0.0-beta.37.tgz#b494136043f3c6ba84fe4a47d4c028c2a63c9a8e"
@@ -4344,14 +4635,6 @@ web3-net@1.0.0-beta.37:
     web3-core-method "1.0.0-beta.37"
     web3-utils "1.0.0-beta.37"
 
-web3-providers-http@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz#e561b52bbb43766282007d40285bfe3550c27e7a"
-  integrity sha1-5WG1K7tDdmKCAH1AKFv+NVDCfno=
-  dependencies:
-    web3-core-helpers "1.0.0-beta.34"
-    xhr2 "0.1.4"
-
 web3-providers-http@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.0.0-beta.37.tgz#c06efd60e16e329e25bd268d2eefc68d82d13651"
@@ -4359,15 +4642,6 @@ web3-providers-http@1.0.0-beta.37:
   dependencies:
     web3-core-helpers "1.0.0-beta.37"
     xhr2-cookies "1.1.0"
-
-web3-providers-ipc@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.34.tgz#a1b77f1a306d73649a9c039052e40cb71328d00a"
-  integrity sha1-obd/GjBtc2SanAOQUuQMtxMo0Ao=
-  dependencies:
-    oboe "2.1.3"
-    underscore "1.8.3"
-    web3-core-helpers "1.0.0-beta.34"
 
 web3-providers-ipc@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -4378,15 +4652,6 @@ web3-providers-ipc@1.0.0-beta.37:
     underscore "1.8.3"
     web3-core-helpers "1.0.0-beta.37"
 
-web3-providers-ws@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz#7de70f1b83f2de36476772156becfef6e3516eb3"
-  integrity sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=
-  dependencies:
-    underscore "1.8.3"
-    web3-core-helpers "1.0.0-beta.34"
-    websocket "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
-
 web3-providers-ws@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.37.tgz#77c15aebc00b75d760d22d063ac2e415bdbef72f"
@@ -4395,16 +4660,6 @@ web3-providers-ws@1.0.0-beta.37:
     underscore "1.8.3"
     web3-core-helpers "1.0.0-beta.37"
     websocket "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
-
-web3-shh@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.0.0-beta.34.tgz#975061d71eaec42ccee576f7bd8f70f03844afe0"
-  integrity sha1-l1Bh1x6uxCzO5Xb3vY9w8DhEr+A=
-  dependencies:
-    web3-core "1.0.0-beta.34"
-    web3-core-method "1.0.0-beta.34"
-    web3-core-subscriptions "1.0.0-beta.34"
-    web3-net "1.0.0-beta.34"
 
 web3-shh@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -4415,19 +4670,6 @@ web3-shh@1.0.0-beta.37:
     web3-core-method "1.0.0-beta.37"
     web3-core-subscriptions "1.0.0-beta.37"
     web3-net "1.0.0-beta.37"
-
-web3-utils@1.0.0-beta.34:
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.0.0-beta.34.tgz#9411fc39aaef39ca4e06169f762297d9ff020970"
-  integrity sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=
-  dependencies:
-    bn.js "4.11.6"
-    eth-lib "0.1.27"
-    ethjs-unit "0.1.6"
-    number-to-bn "1.7.0"
-    randomhex "0.1.5"
-    underscore "1.8.3"
-    utf8 "2.1.1"
 
 web3-utils@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -4466,19 +4708,6 @@ web3@^0.18.4:
     xhr2 "*"
     xmlhttprequest "*"
 
-"web3v1@npm:web3@1.0.0-beta.34":
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/web3/-/web3-1.0.0-beta.34.tgz#347e561b784098cb5563315f490479a1d91f2ab1"
-  integrity sha1-NH5WG3hAmMtVYzFfSQR5odkfKrE=
-  dependencies:
-    web3-bzz "1.0.0-beta.34"
-    web3-core "1.0.0-beta.34"
-    web3-eth "1.0.0-beta.34"
-    web3-eth-personal "1.0.0-beta.34"
-    web3-net "1.0.0-beta.34"
-    web3-shh "1.0.0-beta.34"
-    web3-utils "1.0.0-beta.34"
-
 websocket@^1.0.28:
   version "1.0.32"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.32.tgz#1f16ddab3a21a2d929dec1687ab21cfdc6d3dbb1"
@@ -4510,12 +4739,26 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
+which@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
 which@^1.1.1, which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
+
+wide-align@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
+  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
+  dependencies:
+    string-width "^1.0.2 || 2"
 
 window-size@^0.2.0:
   version "0.2.0"
@@ -4531,6 +4774,11 @@ wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+
+workerpool@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.0.0.tgz#85aad67fa1a2c8ef9386a1b43539900f61d03d58"
+  integrity sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
@@ -4602,11 +4850,6 @@ xhr2@*:
   resolved "https://registry.yarnpkg.com/xhr2/-/xhr2-0.2.0.tgz#eddeff782f3b7551061b8d75645085269396e521"
   integrity sha512-BDtiD0i2iKPK/S8OAZfpk6tyzEDnKKSjxWHcMBVmh+LuqJ8A32qXTyOx+TVOg2dKvq6zGBq2sgKPkEeRs1qTRA==
 
-xhr2@0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/xhr2/-/xhr2-0.1.4.tgz#7f87658847716db5026323812f818cadab387a5f"
-  integrity sha1-f4dliEdxbbUCYyOBL4GMras4el8=
-
 xhr@^2.0.4, xhr@^2.3.3:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/xhr/-/xhr-2.5.0.tgz#bed8d1676d5ca36108667692b74b316c496e49dd"
@@ -4642,10 +4885,18 @@ yaeti@^0.0.6:
   resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
   integrity sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=
 
-yargs-parser@^13.1.0:
+yargs-parser@13.1.2, yargs-parser@^13.1.0, yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
+  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
@@ -4657,6 +4908,17 @@ yargs-parser@^2.4.1:
   dependencies:
     camelcase "^3.0.0"
     lodash.assign "^4.0.6"
+
+yargs-unparser@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-1.6.1.tgz#bd4b0ee05b4c94d058929c32cb09e3fce71d3c5f"
+  integrity sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==
+  dependencies:
+    camelcase "^5.3.1"
+    decamelize "^1.2.0"
+    flat "^4.1.0"
+    is-plain-obj "^1.1.0"
+    yargs "^14.2.3"
 
 yargs@13.2.4:
   version "13.2.4"
@@ -4675,7 +4937,40 @@ yargs@13.2.4:
     y18n "^4.0.0"
     yargs-parser "^13.1.0"
 
-yargs@^4.6.0, yargs@^4.7.1:
+yargs@13.3.2:
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
+  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.2"
+
+yargs@^14.2.3:
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
+  integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
+  dependencies:
+    cliui "^5.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^15.0.1"
+
+yargs@^4.6.0:
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.8.1.tgz#c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0"
   integrity sha1-wMQpJMpKqmsObaFznfshZDn53cA=


### PR DESCRIPTION
Massive PR to upgrade to truffle 5.1.43

- Latest truffle uses web3 v1 which required a lot of changes in tests due to values returned differently.
- Truffle now injects v1 web3 to tests so no need to hack in an additional web3 (v1) for tests anymore (removed package). 
- As part of reorg changed all `BigNumber.js` variables to web3 native 'BN.js' vars (removed Bignumber package)